### PR TITLE
chore(repo): set up initial monorepo infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Give us support by sending us any new features you might like.
+title: ''
+labels: ''
+assignees: ''
+---
+
+### Summary
+
+Briefly describe the new feature you want to add...

--- a/.github/ISSUE_TEMPLATE/ISSUE_SUBMIT.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_SUBMIT.md
@@ -1,0 +1,23 @@
+---
+name: Issue Submit
+about: Help us to improve by reporting and submitting issues you might find.
+title: ''
+labels: ''
+assignees: ''
+---
+
+### Summary
+
+Briefly describe the issue you are experiencing...
+
+### Steps to Reproduce
+
+Tell us how to reproduce this issue...
+
+### Expected behavior
+
+Describe the expected behavior of the new feature...
+
+### Actual behavior
+
+Tell us what happens instead of the expected behavior...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+Provide a general summary of your changes in this section...
+
+## Checklist before requesting a review
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] I have added necessary documentation (if appropriate).

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.9.x
+
+      - name: Verify dependencies
+        run: deno ci
+
+      - name: Lint and format
+        run: deno task lint
+
+      - name: Type-check
+        run: deno task check
+
+      - name: Validate JSDoc
+        run: deno task jsdoc:lint
+
+      - name: Test
+        run: deno task test
+
+      - name: Publish to JSR
+        run: deno publish --check=all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.9.x
+
+      - name: Verify dependencies
+        run: deno ci
+
+      - name: Lint and format
+        run: deno task lint
+
+      - name: Type-check
+        run: deno task check
+
+      - name: Validate JSDoc
+        run: deno task jsdoc:lint
+
+      - name: Run tests
+        run: deno task test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - latest
   pull_request:
   workflow_dispatch:
 
@@ -14,7 +16,7 @@ concurrency:
 
 jobs:
   test:
-    name: Test
+    name: Quality checks
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
 
 permissions:
   pull-requests: read

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -1,0 +1,33 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^((\[unstable\] (BREAKING|deprecation))|BREAKING|deprecation|feature|release|fix|docs|refactor|perf|test|ci|chore|revert)\([a-z][a-z0-9-]*\): [a-z].*$'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "Invalid pull request title: $PR_TITLE"
+            echo
+            echo "Use: <type>(<module>): <lowercase title>"
+            echo "Examples:"
+            echo "  feature(reactivity): add computed signals"
+            echo "  fix(i18n): preserve escaped commas"
+            echo "  [unstable] BREAKING(router): replace route matcher"
+            exit 1
+          fi

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -19,15 +19,32 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^((\[unstable\] (BREAKING|deprecation))|BREAKING|deprecation|feature|release|fix|docs|refactor|perf|test|ci|chore|revert)\([a-z][a-z0-9-]*\): [a-z].*$'
+          # Add each top-level module directory to this array.
+          # Use "repo" for changes that affect the project as a whole.
+          allowed_modules=(
+            "repo"
+          )
+
+          pattern='^((\[unstable\] (BREAKING|deprecation))|BREAKING|deprecation|feature|release|fix|docs|refactor|perf|test|ci|chore|revert)\(([a-z][a-z0-9-]*)\): [a-z].*$'
 
           if [[ ! "$PR_TITLE" =~ $pattern ]]; then
             echo "Invalid pull request title: $PR_TITLE"
             echo
             echo "Use: <type>(<module>): <lowercase title>"
             echo "Examples:"
-            echo "  feature(reactivity): add computed signals"
-            echo "  fix(i18n): preserve escaped commas"
-            echo "  [unstable] BREAKING(router): replace route matcher"
+            echo "  feature(repo): add computed signals"
+            echo "  fix(repo): preserve escaped commas"
+            echo "  chore(repo): update shared configuration"
+            echo "  [unstable] BREAKING(repo): replace signal behavior"
+            exit 1
+          fi
+
+          module="${BASH_REMATCH[4]}"
+
+          if [[ ! " ${allowed_modules[*]} " =~ " ${module} " ]]; then
+            echo "Invalid pull request module: $module"
+            echo
+            echo "Allowed modules: ${allowed_modules[*]}"
+            echo "Use \"repo\" for changes that affect the project as a whole."
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# Deno
+.coverage
+.docs
+
+# AI Tools
+.agents
+.claude
+
+# misc
+.DS_Store
+*.pem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.config": "./deno.json",
+  "editor.rulers": [100],
+  "editor.formatOnSave": true,
+  "cSpell.diagnosticLevel": "Warning",
+  "workbench.iconTheme": "material-icon-theme",
+  "terminal.integrated.defaultProfile.linux": "zsh",
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,175 @@
+# Fragment contributor instructions
+
+## Project overview
+
+Fragment is a Deno 2.9+ TypeScript monorepo for framework-agnostic web application tooling. Each top-level module is developed as an independent workspace package and may be published to JSR under the `@deft-plus` scope.
+
+Keep shared behavior framework-independent. Framework-specific integrations must depend on public module APIs and must not leak framework runtime concepts into foundational packages.
+
+## Repository structure
+
+- Each publishable module lives in a top-level directory such as `reactivity/` or `i18n/`.
+- Root configuration, workflows, documentation, and contributor tooling apply to every module.
+- `.github/workflows/` validates changes and publishes workspace packages.
+- `deno.json` defines the workspace, shared tasks, compiler options, formatting, and linting.
+
+Every module should follow this basic layout:
+
+```text
+<module>/
+├── deno.json
+├── mod.ts
+├── README.md
+├── <api>.ts
+└── <api>_test.ts
+```
+
+- The module's `deno.json` owns its JSR `name`, `version`, and `exports`.
+- `mod.ts` is the deliberate public entry point. Export only supported APIs.
+- Keep tests beside their implementation and name them `*_test.ts`.
+- Prefix implementation-only files with `_` when the distinction is useful.
+- A workspace member that must not be published must set `"publish": false`.
+
+## Quality gate
+
+Run commands from the repository root:
+
+```bash
+deno ci
+deno task check
+deno task fmt
+deno task lint
+deno task test
+deno task jsdoc:lint
+```
+
+Run `deno publish --dry-run --allow-dirty` when changing package metadata, exports, dependencies, or published files. Run `deno task coverage` after `deno task test` when an HTML coverage report is useful.
+
+The test task runs tests across the complete workspace, reports coverage, and enforces a 100% threshold. Do not weaken the threshold to make a change pass.
+
+## Pull request conventions
+
+PR titles must use a semantic type and a lowercase module scope:
+
+```text
+BREAKING(module): title...
+[unstable] BREAKING(module): title...
+deprecation(module): title...
+[unstable] deprecation(module): title...
+feature(module): title...
+release(module): title...
+fix(module): title...
+docs(module): title...
+refactor(module): title...
+perf(module): title...
+test(module): title...
+ci(module): title...
+chore(module): title...
+revert(module): title...
+```
+
+- Use the affected module directory as the scope. Use `repo` for repository-wide changes.
+- Keep the module scope lowercase and use hyphens between words.
+- Begin the title after the colon with a lowercase letter.
+- Use the `[unstable]` prefix only with `BREAKING` or `deprecation`.
+
+## Source conventions
+
+- Begin every TypeScript source file with this exact header:
+
+  ```ts
+  // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+  ```
+
+- Use explicit `.ts` extensions for relative imports and configured aliases for package dependencies.
+- Use one import declaration per module specifier. Combine value and type imports with inline `type` modifiers.
+- Preserve strict TypeScript types. Avoid `any`, non-null assertions, unchecked casts, and broad `Function` types unless they are required and documented.
+- Use two-space indentation, single quotes, and a 100-column TypeScript line width.
+- Prefer Deno and web platform APIs over dependencies that duplicate built-in behavior.
+- Do not grant `-A` to routine commands or tests. Request only the permissions the behavior requires.
+- Do not use TypeScript accessibility keywords for class members. Use ECMAScript `#private` fields and methods for implementation-private state.
+
+## Documentation conventions
+
+- All declaration documentation must use JSDoc comments beginning with `/**`. Never use plain block comments (`/* ... */`) or consecutive line comments (`// ...`) to document a declaration.
+- Document every function, class, interface, type alias, enum, namespace, top-level variable, and top-level constant, whether public or internal.
+- Document every class and interface member, including constructors, properties, accessors, methods, and call signatures. Self-explanatory members may use concise one-line JSDoc.
+- Comments should have a 80 characters length, links and other longs texts are excluded but keep it 80 long.
+- Local implementation comments that explain control flow may use `//`; they are not substitutes for declaration JSDoc.
+- Give every regular source file a descriptive module-level JSDoc block containing `@module` immediately after the copyright header and blank line.
+- Explain the module's purpose, responsibilities, important exports, typical workflow, and relevant constraints without merely repeating its filename.
+- Modules exposing important user-facing behavior must include a practical, titled `@example` using a fenced `ts` block.
+- `mod.ts` and test files use only the copyright header followed by a blank line; they do not require module-level JSDoc.
+- Document every public API with its behavior, parameters, return value, type parameters, and a realistic titled `@example` when it adds useful context.
+- Keep public signatures free of private referenced types so `deno doc --lint` succeeds.
+- Order public API documentation as: summary and details, `@example`, `@template`, `@param`, and `@returns`.
+- Format tags exactly as `@template T - Description.`, `@param value - Description.`, and `@returns Description.`.
+- Give internal declarations concise but complete JSDoc. Put `@internal` last, separated from parameter and return tags by a blank JSDoc line.
+- Every top-level constant requires JSDoc. A public constant may use concise one-line JSDoc. An internal constant must use a multiline JSDoc block with `@internal` on its own line.
+- Update the module README and relevant detailed documentation alongside user-visible behavior.
+- Describe planned capabilities as planned until implementation and tests exist.
+
+Use this exact structure as the documentation reference:
+
+````ts
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Provides the public utilities for creating and using a typed resource.
+ *
+ * Use {@link createResource} to initialize the resource, then call its
+ * methods to read or update values. The module validates inputs before
+ * applying changes and reports invalid operations with {@link ResourceError}.
+ *
+ * @example Create and read a resource
+ * ```ts
+ * const resource = createResource({ name: 'Example' });
+ * console.log(resource.get('name'));
+ * ```
+ *
+ * @module
+ */
+
+/**
+ * Description of the public API.
+ *
+ * @example Usage
+ * ```ts
+ * const result = createThing(value);
+ * ```
+ *
+ * @template T - Type information.
+ * @param value - Parameter information.
+ * @returns Return information.
+ *
+ * @internal
+ */
+function remove<T>(text: T): string {
+  // Implementation...
+}
+
+/**
+ * Description of the internal constant.
+ * @internal
+ */
+const INTERNAL_CONST = 'internal';
+
+/** Description of the public constant. */
+const PUBLIC_CONST = 'public';
+````
+
+## Testing conventions
+
+- Register independent top-level cases with `Deno.test(name, fn)` and arrow functions. Do not use BDD wrappers or test steps.
+- Prefer `@std/expect` for expectations and `@std/testing/mock` only for spies and stubs.
+- Name tests `<function-or-method>() <behavior>` and include parentheses after callable names.
+- Keep tests deterministic and isolated from ambient network, filesystem, locale, timezone, permissions, and environment state unless the test explicitly controls them.
+- Add focused regression coverage for every bug fix and boundary coverage for new behavior.
+- Assert complete structures when fields, ordering, discriminants, or optionality are part of the contract.
+
+## Releases
+
+- Keep each publishable module's version and lockfile state synchronized before creating a GitHub release.
+- The release workflow runs the complete quality gate and publishes every eligible workspace member with `deno publish --check=all`.
+- JSR publishing uses GitHub Actions OIDC provenance; do not add a long-lived JSR token.
+- Do not publish internal helpers or unfinished APIs merely to make tests import them.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Fragment
+
+🧩 **Fragment is a framework-agnostic TypeScript ecosystem providing everything
+you need to build complete applications across different frameworks. ⚡️🚀.** ⚡
+
+> [!IMPORTANT]
+> Fragment is in its initial development stage. APIs and packages are not ready
+> for production use yet.
+
+## Goals
+
+- Provide reusable application tooling without coupling it to a UI framework.
+- Keep every capability independently installable and usable.
+- Offer first-class integrations for different frameworks through thin adapters.
+- Share consistent types, tooling, testing, documentation, and release practices
+  across the ecosystem.
+
+| Module     | Description                              | Status      |
+| ---------- | ---------------------------------------- | ----------- |
+| `reactive` | 🎯 Effortless reactive values            | Coming Soon |
+| `i18n`     | 🌍 Internationalization and localization | Coming Soon |
+
+<!--
+Thinking if adding the following modules
+| `testing`    | 🧪 Comprehensive testing utilities             | Coming Soon |
+| `runtime`    | ⏱️ Runtime utilities and helpers               | Coming Soon |
+| `core`       | 🔥 Fine-grained reactivity and components      | Coming Soon |
+| `directives` | 🚦 Render expressions and directives           | Coming Soon |
+| `cli`        | 🛠️ Command-line interface and utilities        | Coming Soon |
+| `compiler`   | 🧱 Compiler and build tools                    | Coming Soon |
+| `styled`     | 🎨 Scoped and dynamic styling                  | Coming Soon |
+| `forms`      | 📝 Simplified form handling                    | Coming Soon |
+| `http`       | 🌐 Seamless API communication                  | Coming Soon |
+| `graphql`    | 🛰️ GraphQL queries and mutations               | Coming Soon |
+| `motion`     | 🕺 Smooth and declarative animations           | Coming Soon |
+| `server`     | 🚀 Server-side rendering and static generation | Coming Soon |
+| `db`         | 🗄️ Robust data management and queries          | Coming Soon |
+-->
+
+## Development
+
+Fragment requires Deno 2.9 or newer.
+
+```bash
+deno ci
+deno task lint
+deno task check
+deno task test
+```
+
+Useful additional tasks:
+
+```bash
+deno task fmt             # Format the workspace
+deno task test:u          # Update snapshots and run the covered test suite
+deno task coverage        # Generate an HTML coverage report
+deno task jsdoc:lint      # Validate public API documentation
+deno task jsdoc:generate  # Generate local API documentation
+```
+
+The test task discovers tests across every workspace module, reports coverage,
+and requires 100% coverage.
+
+## Pull requests
+
+PR titles follow `<type>(<module>): <lowercase title>`, for example:
+
+```text
+feature(reactivity): add writable signals
+fix(i18n): preserve escaped commas
+docs(repo): explain the workspace layout
+```
+
+See [`AGENTS.md`](./AGENTS.md) for the complete contribution, testing,
+documentation, and release conventions.
+
+## Publishing
+
+Creating a GitHub release runs the complete quality gate and publishes eligible
+workspace packages to JSR with provenance. Package versions must be updated in
+their module configuration before the release is created.
+
+## License
+
+Fragment is available under the [Apache License 2.0](./LICENSE).

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.2",
+  "allowCompoundWords": true,
+  "ignorePaths": [".vscode", ".github/workflows"],
+  "words": ["deno", "denoland", "claude"]
+}

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,53 @@
+{
+  "workspace": [""],
+  "tasks": {
+    "check": "deno check",
+    "lint": "deno lint --permit-no-files && deno fmt --check",
+    "fmt": "deno fmt",
+    "test": "deno test --coverage=.coverage --coverage-threshold=100 --clean --permit-no-files",
+    "test:u": "deno test -u --coverage=.coverage --coverage-threshold=100 --clean --permit-no-files",
+    "coverage": "deno coverage --html --output=.coverage/html .coverage",
+    "jsdoc:lint": "deno doc --lint '*/**/*.ts'",
+    "jsdoc:generate": "deno doc --html --output=.docs '*/**/*.ts'"
+  },
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "dom.extras", "deno.ns"],
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "exclude": [".git", ".coverage", ".docs"],
+  "fmt": {
+    "include": ["./"],
+    "useTabs": false,
+    "lineWidth": 100,
+    "indentWidth": 2,
+    "singleQuote": true,
+    "proseWrap": "never"
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"],
+      "include": [
+        "no-console",
+        "no-eval",
+        "eqeqeq",
+        "camelcase",
+        "no-self-compare",
+        "ban-untagged-todo",
+        "no-external-import",
+        "no-sparse-arrays",
+        "no-non-null-assertion",
+        "no-non-null-asserted-optional-chain",
+        "explicit-function-return-type",
+        "explicit-module-boundary-types",
+        "no-sync-fn-in-async-fn",
+        "single-var-declarator",
+        "verbatim-module-syntax",
+        "no-throw-literal",
+        "prefer-ascii"
+      ],
+      "exclude": ["no-empty-interface"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Sets up the initial infrastructure for the Fragment monorepo and establishes the conventions that future modules will follow.

- Configure the Deno workspace for root-level modules
- Add shared formatting, linting, type-checking, testing, coverage, and JSDoc tasks
- Enforce complete test coverage
- Add GitHub Actions for:
  - Code quality and tests
  - PR title validation
  - Publishing releases to JSR
- Define the supported PR title conventions
- Add `AGENTS.md` with TypeScript, testing, and JSDoc guidelines
- Add the initial project README
- Add editor, spelling, and GitHub contribution configuration

## Checklist before requesting a review

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).