### PR TITLE
feature(reactivity): add reactive state management

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -24,6 +24,7 @@ jobs:
           # Use "repo" for changes that affect the project as a whole.
           allowed_modules=(
             "repo"
+            "reactivity"
           )
 
           pattern='^((\[unstable\] (BREAKING|deprecation))|BREAKING|deprecation|feature|release|fix|docs|refactor|perf|test|ci|chore|revert)\(([a-z][a-z0-9-]*)\): [a-z].*$'

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # Fragment
 
-🧩 **Fragment is a framework-agnostic TypeScript ecosystem providing everything
-you need to build complete applications across different frameworks. ⚡️🚀.** ⚡
+🧩 **Fragment is a framework-agnostic TypeScript ecosystem providing everything you need to build complete applications across different frameworks. ⚡️🚀.** ⚡
 
 > [!IMPORTANT]
-> Fragment is in its initial development stage. APIs and packages are not ready
-> for production use yet.
+> Fragment is in its initial development stage. APIs and packages are not ready for production use yet.
 
 ## Goals
 
 - Provide reusable application tooling without coupling it to a UI framework.
 - Keep every capability independently installable and usable.
 - Offer first-class integrations for different frameworks through thin adapters.
-- Share consistent types, tooling, testing, documentation, and release practices
-  across the ecosystem.
+- Share consistent types, tooling, testing, documentation, and release practices across the ecosystem.
 
 | Module     | Description                              | Status      |
 | ---------- | ---------------------------------------- | ----------- |
@@ -58,8 +55,7 @@ deno task jsdoc:lint      # Validate public API documentation
 deno task jsdoc:generate  # Generate local API documentation
 ```
 
-The test task discovers tests across every workspace module, reports coverage,
-and requires 100% coverage.
+The test task discovers tests across every workspace module, reports coverage, and requires 100% coverage.
 
 ## Pull requests
 
@@ -71,14 +67,11 @@ fix(i18n): preserve escaped commas
 docs(repo): explain the workspace layout
 ```
 
-See [`AGENTS.md`](./AGENTS.md) for the complete contribution, testing,
-documentation, and release conventions.
+See [`AGENTS.md`](./AGENTS.md) for the complete contribution, testing, documentation, and release conventions.
 
 ## Publishing
 
-Creating a GitHub release runs the complete quality gate and publishes eligible
-workspace packages to JSR with provenance. Package versions must be updated in
-their module configuration before the release is created.
+Creating a GitHub release runs the complete quality gate and publishes eligible workspace packages to JSR with provenance. Package versions must be updated in their module configuration before the release is created.
 
 ## License
 

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "workspace": [""],
+  "workspace": ["./reactivity"],
   "tasks": {
     "check": "deno check",
     "lint": "deno lint --permit-no-files && deno fmt --check",

--- a/deno.lock
+++ b/deno.lock
@@ -4,9 +4,12 @@
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@^1.5.0": "1.5.0",
     "jsr:@std/data-structures@^1.1.1": "1.1.2",
+    "jsr:@std/data-structures@^1.1.2": "1.1.2",
     "jsr:@std/expect@^1.0.20": "1.0.20",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.5": "1.1.6",
     "jsr:@std/path@^1.1.6": "1.1.6",
     "jsr:@std/testing@^1.0.20": "1.0.20"
   },
@@ -20,7 +23,7 @@
     "@std/async@1.5.0": {
       "integrity": "4c1f22d287a17ad7d8643b1952bc5a4d21e5d8b68dc8c20d8268eecc69096e82",
       "dependencies": [
-        "jsr:@std/data-structures"
+        "jsr:@std/data-structures@^1.1.1"
       ]
     },
     "@std/data-structures@1.1.2": {
@@ -31,7 +34,13 @@
       "dependencies": [
         "jsr:@std/assert",
         "jsr:@std/internal@^1.0.14",
-        "jsr:@std/path"
+        "jsr:@std/path@^1.1.6"
+      ]
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/path@^1.1.5"
       ]
     },
     "@std/internal@1.0.14": {
@@ -46,7 +55,12 @@
     "@std/testing@1.0.20": {
       "integrity": "21380ed438672762e4ec549cbf4fe41c5b68f5598773a30b64abe7375513e721",
       "dependencies": [
-        "jsr:@std/assert"
+        "jsr:@std/assert",
+        "jsr:@std/async",
+        "jsr:@std/data-structures@^1.1.2",
+        "jsr:@std/fs",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.6"
       ]
     }
   },

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,64 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.5.0": "1.5.0",
+    "jsr:@std/data-structures@^1.1.1": "1.1.2",
+    "jsr:@std/expect@^1.0.20": "1.0.20",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.6": "1.1.6",
+    "jsr:@std/testing@^1.0.20": "1.0.20"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/async@1.5.0": {
+      "integrity": "4c1f22d287a17ad7d8643b1952bc5a4d21e5d8b68dc8c20d8268eecc69096e82",
+      "dependencies": [
+        "jsr:@std/data-structures"
+      ]
+    },
+    "@std/data-structures@1.1.2": {
+      "integrity": "2471377c9e0051f9ec34e57d0ebd0ad133a5a889677446ec6ba9938e4e102918"
+    },
+    "@std/expect@1.0.20": {
+      "integrity": "ffc4f3c33f732417e3e9acf3d995818c89984313c37d933b9ebbb4571d2887e9",
+      "dependencies": [
+        "jsr:@std/assert",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    },
+    "@std/testing@1.0.20": {
+      "integrity": "21380ed438672762e4ec549cbf4fe41c5b68f5598773a30b64abe7375513e721",
+      "dependencies": [
+        "jsr:@std/assert"
+      ]
+    }
+  },
+  "workspace": {
+    "members": {
+      "reactivity": {
+        "dependencies": [
+          "jsr:@std/async@^1.5.0",
+          "jsr:@std/expect@^1.0.20",
+          "jsr:@std/testing@^1.0.20"
+        ]
+      }
+    }
+  }
+}

--- a/reactivity/README.md
+++ b/reactivity/README.md
@@ -1,0 +1,251 @@
+# 🎯 Reactivity
+
+[![JSR](https://jsr.io/badges/@deft-plus/reactivity)](https://jsr.io/@deft-plus/reactivity) [![JSR Score](https://jsr.io/badges/@deft-plus/reactivity/score)](https://jsr.io/@deft-plus/reactivity)
+
+The `@deft-plus/reactivity` module combines the power of reactive signals and stores to manage both individual reactive values and global state in your application. With this module, you can create reactive values (signals), manage derived values, and encapsulate state in stores, all with minimal boilerplate and a functional programming style.
+
+## Installation
+
+Install the `@deft-plus/reactivity` package using deno:
+
+```bash
+deno add @deft-plus/reactivity
+```
+
+Or using npm:
+
+```bash
+npx jsr add @deft-plus/reactivity
+```
+
+### Global logging
+
+Set `SIGNAL_LOG=true` to enable logging for every signal when the application grants access to that environment variable:
+
+```bash
+SIGNAL_LOG=true deno run --allow-env=SIGNAL_LOG app.ts
+```
+
+Without environment permission, global logging safely remains disabled. A signal-level `log` option always takes precedence, so `{ log: false }` can disable logging for an individual signal.
+
+## Signals
+
+Signals provide a way to create reactive values that automatically notify consumers when their value changes. They allow for fine-grained reactivity and lazy evaluation, making them ideal for performance-sensitive applications.
+
+### Basics
+
+A signal is a function (`() => T`) that returns its current value. It doesn't trigger side effects but may recompute values lazily.
+
+**Reactive Contexts:** When a signal is accessed in a reactive context, it registers as a dependency. The context updates when any signal it depends on changes.
+
+### Writable Signals
+
+Use `signal()` to create a `WritableSignal`. Writable signals allow updating their value using:
+
+- `.set(value)`: Update the signal's value.
+- `.update(func)`: Update using a function.
+- `.mutate(func)`: Modify the current value directly.
+
+Example:
+
+```typescript
+import { signal } from '@deft-plus/reactivity';
+
+const counter = signal(0);
+
+counter.set(2);
+counter.update((count) => count + 1);
+counter.mutate((list) => list.push({ title: 'New Task' }));
+```
+
+**Equality Comparator:** Optionally, provide a function to compare new and old values to prevent unnecessary updates.
+
+### Read-Only Signals
+
+Create a read-only signal with `signal(value).readonly()`. It restricts mutation and only allows access to the value.
+
+Example:
+
+```typescript
+const readonlyCounter = signal(0).readonly();
+```
+
+### Memoized Signals
+
+Use `memoSignal()` to create memoized signals that automatically update based on dependencies.
+
+Example:
+
+```typescript
+import { memoSignal } from '@deft-plus/reactivity';
+
+const isEven = memoSignal(() => counter() % 2 === 0);
+```
+
+Memoized signals can be configured with an equality comparator to prevent unnecessary updates and an `subscribe` hook to run when the value changes.
+
+### Signal Conversion
+
+`toSignal()` creates signals that represent asynchronous values. The signal resolves to a promise and exposes a `status` property.
+
+Example:
+
+```typescript
+import { toSignal } from '@deft-plus/reactivity';
+
+// Function parameter.
+const data = toSignal(async () => {
+  const response = await fetch('https://api.example.com/data');
+  return response.json();
+});
+
+// Promise parameter.
+const data = toSignal(
+  fetch('https://api.example.com/data')
+    .then((response) => response.json()),
+);
+```
+
+### Event Signals
+
+You can also use events to trigger signal updates. Just dispatch an event with the signal's name and the new value.
+
+Example:
+
+```typescript
+import { signal } from '@deft-plus/reactivity';
+
+using counter = signal(0, { name: 'counter', allowEvents: true });
+
+dispatchEvent(new CustomEvent('counter', { detail: 1 }));
+
+console.log(counter()); // 1
+```
+
+This allows you to update signals from event listeners, making it easy to integrate with other parts of your application. It also uses the Dispose pattern to clean up event listeners when the signal is disposed. You can also use the `onDispose` hook to run cleanup code when the signal is disposed.
+
+Example:
+
+```typescript
+import { signal } from '@deft-plus/reactivity';
+{
+  using counter = signal(0, {
+    name: 'counter',
+    allowEvents: true,
+    onDispose: () => {
+      console.log('Disposed');
+    },
+  });
+
+  dispatchEvent(new CustomEvent('counter', { detail: 1 }));
+
+  console.log(counter()); // 1
+} // Logs: "Disposed"
+```
+
+### Effects
+
+`effect()` registers side effects that run whenever the signals they depend on change. Effects can be cleaned up by returning a cleanup function.
+
+Example:
+
+```typescript
+import { effect, signal } from '@deft-plus/reactivity';
+
+const counter = signal(0);
+
+effect(() => {
+  console.log('Counter:', counter());
+  return () => console.log('Cleanup');
+});
+
+// Run effect immediately.
+effect.initial(() => {
+  console.log('Counter:', counter());
+});
+```
+
+### Untracked Signals
+
+Use `signal.untracked()` to access a signal's value without registering it as a dependency in a reactive context.
+
+---
+
+## Stores
+
+Stores allow you to manage multiple reactive values in a cohesive, encapsulated structure. They are ideal for managing global or complex state, ensuring atomic updates and immutability.
+
+### Why Use Stores?
+
+- **Encapsulation**: Keep state and logic organized.
+- **Atomic Updates**: Prevent unintended side effects.
+- **Derived Values**: Easily compute values based on existing state.
+- **Immutability**: Ensure state cannot be directly mutated, reducing bugs.
+
+### Creating a Store
+
+A store is an object containing signals and actions. It leverages signals internally to manage and update state reactively.
+
+Example:
+
+```typescript
+import { store } from '@deft-plus/reactivity';
+
+type CounterStore = {
+  count: number;
+  increment: () => void;
+  decrement: () => void;
+  reset: () => void;
+};
+
+const counterStore = store<CounterStore>(({ get }) => ({
+  count: 0,
+  increment: () => get().count.update((count) => count + 1),
+  decrement: () => get().count.update((count) => count - 1),
+  reset: () => get().count.set(0),
+}));
+
+console.log(counterStore.count()); // 0
+counterStore.increment();
+console.log(counterStore.count()); // 1
+```
+
+### Working with Derived Values
+
+Stores can include derived values that depend on other signals. These derived values are memoized and update automatically.
+
+Example:
+
+```typescript
+import { store } from '@deft-plus/reactivity';
+
+type CounterStore = {
+  count: number;
+  double: number;
+  increment: () => void;
+};
+
+const counterStore = store<CounterStore>(({ get }) => ({
+  count: 0,
+  double: {
+    value: () => get().count() * 2,
+  },
+  increment: () => get().count.update((count) => count + 1),
+}));
+
+console.log(counterStore.double()); // 0
+counterStore.increment();
+console.log(counterStore.double()); // 2
+```
+
+### Accessing Store State
+
+The `get` function provides access to the store's internal signals and actions. Use it to retrieve the current state and trigger updates.
+
+> **Note:** `get` ensures non-nullable access to the store's state, avoiding constant null checks.
+
+---
+
+## Summary
+
+`@deft-plus/reactivity` unifies signals and stores, providing a flexible, efficient way to manage both individual reactive values and global state. With signals, you get fine-grained reactivity and lazy evaluation. With stores, you encapsulate state and logic, making it easy to maintain complex state while ensuring immutability and performance.

--- a/reactivity/_api.ts
+++ b/reactivity/_api.ts
@@ -1,0 +1,280 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains APIs for creating and working with signals.
+ *
+ * A signal is a function that returns a value. Signals can be read-only or writable. Writable
+ * signals are created with the `signal` function, while read-only signals are created by calling
+ * the `readonly` method on a writable signal.
+ *
+ * Signals are used to create reactive graphs. When a signal's value changes, all dependent signals
+ * are notified and re-evaluated.
+ *
+ * @module
+ */
+
+/**
+ * Symbol to identify signal functions.
+ * @internal
+ */
+const SIGNAL = Symbol('signal');
+
+/**
+ * List of signal types.
+ * @internal
+ */
+const SIGNAL_TYPES: SignalType[] = ['writable', 'readonly', 'memoized'];
+
+/**
+ * Gets the type of signal, of a signal.
+ *
+ * @template T - The type of the signal value.
+ * @param signal - Signal to get the type of.
+ * @returns The signal type.
+ */
+export function getSignalType<T>(signal: Signal<T>): SignalType {
+  return (signal as ReadonlySignal<T>)[SIGNAL];
+}
+
+/**
+ * Utility to check if a value is a signal.
+ *
+ * @example Usage
+ * ```ts
+ * if (isSignal(value)) {
+ *   console.log('Value is a signal:', value());
+ * }
+ *
+ * // Or use the type guard.
+ * if (isSignal<string>(value)) {
+ *   console.log('Value is a signal with string typings:', value());
+ * }
+ *
+ * // Or use the type guards for specific signal types.
+ * if (isSignal.writable(value)) {
+ *   console.log('Value is a writable signal:', value());
+ * }
+ *
+ * if (isSignal.readonly(value)) {
+ *   console.log('Value is a read-only signal:', value());
+ * }
+ *
+ * if (isSignal.memoized(value)) {
+ *   console.log('Value is a memoized signal:', value());
+ * }
+ * ```
+ *
+ * @template T - The type of the signal value if the value is a signal.
+ * @param value - Value to check.
+ * @returns `true` if the value is a signal ({@link Signal}), `false` otherwise.
+ */
+export function isSignal<T = unknown>(value: unknown): value is Signal<T> {
+  return typeof value === 'function' && SIGNAL_TYPES.includes((value as ReadonlySignal<T>)[SIGNAL]);
+}
+
+/**
+ * Type guard to check if a value is a writable signal.
+ *
+ * @template T - The type of the signal value if the value is a writable signal.
+ * @param value - Value to check.
+ * @returns `true` if the value is a writable signal ({@link WritableSignal}), `false` otherwise.
+ */
+isSignal.writable = <T = unknown>(value: unknown): value is WritableSignal<T> =>
+  isSignal(value) && getSignalType(value) === 'writable';
+
+/**
+ * Type guard to check if a value is a read-only signal.
+ *
+ * @template T - The type of the signal value if the value is a read-only signal.
+ * @param value - Value to check.
+ * @returns `true` if the value is a read-only signal ({@link ReadonlySignal}), `false` otherwise.
+ */
+isSignal.readonly = <T = unknown>(value: unknown): value is ReadonlySignal<T> =>
+  isSignal(value) && getSignalType(value) === 'readonly';
+
+/**
+ * Type guard to check if a value is a memoized signal.
+ *
+ * @template T - The type of the signal value if the value is a memoized signal.
+ * @param value - Value to check.
+ * @returns `true` if the value is a memoized signal ({@link MemoizedSignal}), `false` otherwise.
+ */
+isSignal.memoized = <T = unknown>(value: unknown): value is MemoizedSignal<T> =>
+  isSignal(value) && getSignalType(value) === 'memoized';
+
+/**
+ * Marks a function as a signal function.
+ *
+ * @template T - Generic to cast the function as either a read-only or writable signal.
+ * @param fn - Function to mark as a signal.
+ * @param extraApi - Extra API to add to the signal.
+ * @returns The marked signal function ({@link Signal}).
+ * @internal
+ */
+export function markAsSignal<T extends Signal>(
+  type: SignalType,
+  fn: () => unknown,
+  extraApi?: Record<string, unknown>,
+): T {
+  (fn as WithSignalSymbol<() => T>)[SIGNAL] = type;
+
+  // Copy properties from `extraApi` to `fn` to complete the desired API of the `Signal`.
+  return Object.assign(fn, extraApi) as T;
+}
+
+/**
+ * Default equality check for signals. Compares objects and arrays as always unequal, and uses
+ * strict equality for primitives.
+ *
+ * @template T - The type of the values to compare.
+ * @param a - First value to compare.
+ * @param b - Second value to compare.
+ * @returns `true` if the values are equal, `false` otherwise.
+ */
+export function defaultEquals<T>(a: T, b: T): boolean {
+  return (a === null || typeof a !== 'object') && Object.is(a, b);
+}
+
+/**
+ * Represents a base signal function. Which in essence is a function that returns a value.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export type BaseSignal<T = unknown> = () => T;
+
+/** Different types of signals. */
+export type SignalType = 'writable' | 'readonly' | 'memoized';
+
+/**
+ * Adds the signal symbol to the given type.
+ *
+ * @template T - The type to add the signal symbol to.
+ */
+export interface WithSignalSymbol<T> extends BaseSignal<T> {
+  /**
+   * Symbol to identify signal type ({@link SignalType}).
+   * @internal
+   */
+  [SIGNAL]: SignalType;
+}
+
+/**
+ * A signal that can be read but not updated.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export interface ReadonlySignal<T = unknown> extends WithSignalSymbol<T> {
+  /** Named of the signal (Useful when the name is not set). */
+  identifier: string;
+  /**
+   * Get the value without creating a dependency.
+   *
+   * @returns The current value without creating a dependency.
+   */
+  untracked(): T;
+}
+
+/**
+ * A signal that can be changed.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export interface WritableSignal<T = unknown> extends ReadonlySignal<T> {
+  /**
+   * Set a new value and notify dependents.
+   *
+   * @param value - New value to set.
+   */
+  set(value: T): void;
+  /**
+   * Update the value based on the current value and notify dependents.
+   *
+   * @param updateFn - Function to update the value.
+   */
+  update(updateFn: (value: T) => T): void;
+  /**
+   * Modify the current value in-place and notify dependents.
+   *
+   * @param mutatorFn - Function to mutate the value.
+   */
+  mutate(mutatorFn: (value: T) => void): void;
+  /**
+   * Get a read-only version of this signal.
+   *
+   * @returns A read-only signal {@linkcode ReadonlySignal}.
+   */
+  readonly(): ReadonlySignal<T>;
+}
+
+/**
+ * A writable signal that can be disposed of.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export interface WritableEventSignal<T = unknown> extends WritableSignal<T> {
+  /** Dispose of the signal and clean up all event listeners. */
+  [Symbol.dispose]: () => void;
+}
+
+/**
+ * A memoized signal that computes the value based on dependencies.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export interface MemoizedSignal<T = unknown> extends ReadonlySignal<T> {}
+
+/**
+ * Union with both the read-only ({@link ReadonlySignal}) and writable signal
+ * ({@link WritableSignal}).
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export type Signal<T = unknown> = ReadonlySignal<T> | WritableSignal<T> | MemoizedSignal<T>;
+
+/**
+ * Options for creating a signal of the given type.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export interface SignalOptions<T> {
+  /** Identifier for the signal. Useful for debugging, update with events and testing. */
+  name?: string;
+  /** Whether to log the signal's changes (Defaults to `false`). */
+  log?: boolean;
+  /**
+   * Function to check if two signal values are equal (Defaults to the built-in equality check
+   * {@link defaultEquals}).
+   *
+   * @param a - First value to compare.
+   * @param b - Second value to compare.
+   * @returns `true` if the values are equal, `false` otherwise.
+   */
+  equal?: (a: T, b: T) => boolean;
+  /**
+   * Function to call after the signal value changes.
+   *
+   * @param newValue - New value of the signal.
+   */
+  subscribe?: (newValue: T, oldValue: T) => void;
+}
+
+/**
+ * Options for creating a signal that can listen for events.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export interface SignalEventOptions<T> extends SignalOptions<T> {
+  /** Whether to allow events to be dispatched (Defaults to `false`). */
+  allowEvents: true;
+  /** Function to call when the signal is disposed. */
+  onDispose?: () => void;
+}
+
+/**
+ * Options for creating a memoized signal.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+export interface MemoizedSignalOptions<T> extends SignalOptions<T> {
+  // Empty for now but could be extended in the future.
+}

--- a/reactivity/_api_test.ts
+++ b/reactivity/_api_test.ts
@@ -1,0 +1,61 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { expect } from '@std/expect';
+
+import { defaultEquals, isSignal, markAsSignal } from './_api.ts';
+import { signal } from './signal.ts';
+import { memoSignal } from './memo.ts';
+
+Deno.test('defaultEquals() should compare two values', () => {
+  expect(defaultEquals(1, 1)).toBe(true);
+  expect(defaultEquals(1, 2)).toBe(false);
+});
+
+Deno.test('defaultEquals() should treat objects as unequal by default', () => {
+  const obj1 = { name: 'Alice', age: 42 };
+  const obj2 = { name: 'Alice', age: 42 };
+
+  expect(defaultEquals(obj1, obj2)).toBe(false);
+});
+
+Deno.test('isSignal() should identify signal values', () => {
+  const notSignal = 42;
+  const validSignal = signal(42);
+
+  expect(isSignal(notSignal)).toBe(false);
+  expect(isSignal(validSignal)).toBe(true);
+});
+
+Deno.test('isSignal() should return false for nullish values', () => {
+  expect(isSignal(undefined)).toBe(false);
+  expect(isSignal(null)).toBe(false);
+  expect(isSignal.writable(undefined)).toBe(false);
+  expect(isSignal.readonly(undefined)).toBe(false);
+  expect(isSignal.memoized(undefined)).toBe(false);
+});
+
+Deno.test('isSignal() type guards should identify specific signal types', () => {
+  const notSignal = 42;
+  const validSignal = signal(42);
+  const validReadonly = validSignal.readonly();
+  const validMemo = memoSignal(() => validSignal());
+
+  expect(isSignal(notSignal)).toBe(false);
+  expect(isSignal(validSignal)).toBe(true);
+
+  expect(isSignal.writable(validSignal)).toBe(true);
+  expect(isSignal.writable(validReadonly)).toBe(false);
+
+  expect(isSignal.readonly(validReadonly)).toBe(true);
+  expect(isSignal.readonly(validMemo)).toBe(false);
+
+  expect(isSignal.memoized(validMemo)).toBe(true);
+  expect(isSignal.memoized(validSignal)).toBe(false);
+});
+
+Deno.test('markAsSignal() should mark a function as a signal', () => {
+  const value = () => 42;
+  const signalValue = markAsSignal('writable', value);
+
+  expect(isSignal(signalValue)).toBe(true);
+});

--- a/reactivity/_logging.ts
+++ b/reactivity/_logging.ts
@@ -1,0 +1,33 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the logging resolver for the configuration.
+ *
+ * @module
+ */
+
+/** Name of the environment variable that enables signal logging globally. */
+const SIGNAL_LOG_ENV = 'SIGNAL_LOG';
+
+/**
+ * Resolves whether logging is enabled for a signal.
+ *
+ * An explicit option takes precedence. Otherwise, the global environment setting is used only when
+ * the runtime grants access to it. Runtimes without the Deno API and denied permissions safely
+ * default to disabled logging.
+ */
+export function resolveSignalLog(log?: boolean): boolean {
+  if (log !== undefined) {
+    return log;
+  }
+
+  // deno-coverage-ignore-start -- Deno's test runner cannot execute without the Deno global.
+  if (typeof Deno === 'undefined') {
+    return false;
+  }
+  // deno-coverage-ignore-stop
+
+  const permission = Deno.permissions.querySync({ name: 'env', variable: SIGNAL_LOG_ENV });
+
+  return permission.state === 'granted' && Deno.env.get(SIGNAL_LOG_ENV) === 'true';
+}

--- a/reactivity/_logging_test.ts
+++ b/reactivity/_logging_test.ts
@@ -1,0 +1,83 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { assertSpyCalls, stub } from '@std/testing/mock';
+import { expect } from '@std/expect';
+
+import { resolveSignalLog } from './_logging.ts';
+import { memoSignal } from './memo.ts';
+import { signal } from './signal.ts';
+import { store } from './store.ts';
+
+const permissionStatus = (state: Deno.PermissionState): Deno.PermissionStatus =>
+  ({ state, partial: false, onchange: null }) as Deno.PermissionStatus;
+
+Deno.test('resolveSignalLog() should prioritize an explicit logging option', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('granted'),
+  );
+
+  expect(resolveSignalLog(true)).toBe(true);
+  expect(resolveSignalLog(false)).toBe(false);
+  assertSpyCalls(permissionStub, 0);
+});
+
+Deno.test('resolveSignalLog() should disable global logging when environment access is denied', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('denied'),
+  );
+  using envStub = stub(Deno.env, 'get', () => 'true');
+
+  expect(resolveSignalLog()).toBe(false);
+  assertSpyCalls(permissionStub, 1);
+  assertSpyCalls(envStub, 0);
+});
+
+Deno.test('resolveSignalLog() should enable global logging when the environment setting is accessible', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('granted'),
+  );
+  using envStub = stub(Deno.env, 'get', () => 'true');
+  using consoleStub = stub(console, 'log', () => {});
+
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
+
+  counter.set(1);
+  expect(doubleCounter()).toBe(2);
+
+  assertSpyCalls(permissionStub, 2);
+  assertSpyCalls(envStub, 2);
+  assertSpyCalls(consoleStub, 6);
+});
+
+Deno.test('resolveSignalLog() should let local options disable global logging', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('granted'),
+  );
+  using envStub = stub(Deno.env, 'get', () => 'true');
+  using consoleStub = stub(console, 'log', () => {});
+
+  const counter = signal(0, { log: false });
+  const doubleCounter = memoSignal(() => counter() * 2, { log: false });
+  const counterStore = store<{ count: number; increment: () => void }>(({ get }) => ({
+    count: { value: 0, log: false },
+    increment: () => get().count.update((value) => value + 1),
+  }));
+
+  counter.set(1);
+  expect(doubleCounter()).toBe(2);
+  counterStore().increment();
+  expect(counterStore().count()).toBe(1);
+
+  assertSpyCalls(permissionStub, 0);
+  assertSpyCalls(envStub, 0);
+  assertSpyCalls(consoleStub, 0);
+});

--- a/reactivity/_reactive_node.ts
+++ b/reactivity/_reactive_node.ts
@@ -1,0 +1,198 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the {@link ReactiveNode} class, which represents a node in the reactive graph and
+ * provides the core functionality for reactivity.
+ *
+ * @module
+ */
+
+/**
+ * Represents a node in the reactive graph. Nodes can act as producers, consumers, or both.
+ */
+export abstract class ReactiveNode {
+  /** Counter for generating unique IDs for producers and consumers. */
+  static #nextId = 0;
+
+  /** The currently active reactive consumer, or `null` if none. */
+  static #activeConsumer: ReactiveNode | null = null;
+
+  /** Whether change notifications are currently being propagated. */
+  static #notifying = false;
+
+  /** Unique identifier for this node. */
+  readonly #id = ReactiveNode.#nextId++;
+
+  /** Weak reference to this node, used in dependencies. */
+  readonly #ref = new WeakRef(this);
+
+  /** Dependencies of this node as a producer. */
+  readonly #producers = new Map<number, Dependency>();
+
+  /** Dependencies of this node as a consumer. */
+  readonly #consumers = new Map<number, Dependency>();
+
+  /** Version of the consumer's dependencies. */
+  trackingVersion = 0;
+
+  /** Version of the producer's value. */
+  valueVersion = 0;
+
+  /** Whether this consumer has any producers. */
+  get hasProducers(): boolean {
+    return this.#producers.size > 0;
+  }
+
+  /**
+   * Sets the active reactive consumer and returns the previous one.
+   *
+   * @param consumer - The new reactive consumer ({@link ReactiveNode}) or `null`.
+   * @returns The previous reactive consumer ({@link ReactiveNode}) or `null` if none.
+   * @internal
+   */
+  static setActiveConsumer(consumer: ReactiveNode | null): ReactiveNode | null {
+    const previous = ReactiveNode.#activeConsumer;
+    ReactiveNode.#activeConsumer = consumer;
+    return previous;
+  }
+
+  /** Called when a dependency may have changed. */
+  onDependencyChange(): void {}
+
+  /** Called when a consumer checks if the producer's value has changed. */
+  onProducerMayChanged(): void {}
+
+  /**
+   * Checks if any of this node's dependencies have actually changed.
+   *
+   * @returns `true` if any dependencies have changed, `false` otherwise.
+   */
+  haveDependenciesChanged(): boolean {
+    for (const [producerId, dependency] of this.#producers) {
+      const producer = dependency.producerRef.deref();
+
+      if (producer === undefined || dependency.consumerVersion !== this.trackingVersion) {
+        // Dependency is stale; remove it.
+        this.#producers.delete(producerId);
+        // deno-coverage-ignore-start -- WeakRef collection cannot be tested deterministically.
+        if (producer !== undefined) {
+          producer.#consumers.delete(this.#id);
+        }
+        // deno-coverage-ignore-stop
+        continue;
+      }
+
+      if (producer.#haveValueChanged(dependency.producerVersion)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /** Notifies consumers that this producer's value may have changed. */
+  notifyConsumers(): void {
+    const wasNotifying = ReactiveNode.#notifying;
+    ReactiveNode.#notifying = true;
+    try {
+      for (const [consumerId, dependency] of this.#consumers) {
+        const consumer = dependency.consumerRef.deref();
+        if (consumer === undefined || consumer.trackingVersion !== dependency.consumerVersion) {
+          this.#consumers.delete(consumerId);
+          // deno-coverage-ignore-start -- WeakRef collection cannot be tested deterministically.
+          if (consumer !== undefined) {
+            consumer.#producers.delete(this.#id);
+          }
+          // deno-coverage-ignore-stop
+          continue;
+        }
+
+        consumer.onDependencyChange();
+      }
+    } finally {
+      ReactiveNode.#notifying = wasNotifying;
+    }
+  }
+
+  /** Records that this producer node was accessed in the current context. */
+  recordAccess(): void {
+    if (ReactiveNode.#notifying) {
+      throw new Error('Cannot read signals during notification phase.');
+    }
+
+    if (ReactiveNode.#activeConsumer === null) {
+      return;
+    }
+
+    let dependency = ReactiveNode.#activeConsumer.#producers.get(this.#id);
+    if (dependency === undefined) {
+      dependency = {
+        consumerRef: ReactiveNode.#activeConsumer.#ref,
+        producerRef: this.#ref,
+        producerVersion: this.valueVersion,
+        consumerVersion: ReactiveNode.#activeConsumer.trackingVersion,
+      };
+      ReactiveNode.#activeConsumer.#producers.set(this.#id, dependency);
+      this.#consumers.set(ReactiveNode.#activeConsumer.#id, dependency);
+    } else {
+      dependency.producerVersion = this.valueVersion;
+      dependency.consumerVersion = ReactiveNode.#activeConsumer.trackingVersion;
+    }
+  }
+
+  /**
+   * Checks if the producer's value has changed compared to the last recorded version.
+   *
+   * @param lastSeenVersion - The last version of the value seen by the consumer.
+   * @returns `true` if the value has changed, `false` otherwise.
+   */
+  #haveValueChanged(lastSeenVersion: number): boolean {
+    if (this.valueVersion !== lastSeenVersion) {
+      return true;
+    }
+
+    this.onProducerMayChanged();
+    return this.valueVersion !== lastSeenVersion;
+  }
+
+  /**
+   * Logs the change of value for debugging purposes.
+   *
+   * @param config - Configuration for logging the change.
+   */
+  log(config: LogConfig): void {
+    const { type, name, newValue, oldValue } = config;
+
+    // Rule disabled because this is a debugging method.
+    // deno-lint-ignore no-console
+    console.log(`[${type}: ${name}]`);
+    // deno-lint-ignore no-console
+    console.log(`  New value:`, JSON.stringify(newValue));
+    // deno-lint-ignore no-console
+    console.log(`  Old value:`, JSON.stringify(oldValue));
+  }
+}
+
+/** Representation of a dependency between a producer and a consumer. */
+interface Dependency {
+  /** Reference to the producer node. */
+  readonly producerRef: WeakRef<ReactiveNode>;
+  /** Reference to the consumer node. */
+  readonly consumerRef: WeakRef<ReactiveNode>;
+  /** Version of the consumer when this dependency was last observed. */
+  consumerVersion: number;
+  /** Version of the producer's value when this dependency was last accessed. */
+  producerVersion: number;
+}
+
+/** Configuration for logging changes in the reactive node. */
+export interface LogConfig {
+  /** Reactive value type displayed in the log heading. */
+  type: string;
+  /** Human-readable name of the reactive value. */
+  name: string;
+  /** Value after the reactive update. */
+  newValue: unknown;
+  /** Value before the reactive update. */
+  oldValue: unknown;
+}

--- a/reactivity/_reactive_node_test.ts
+++ b/reactivity/_reactive_node_test.ts
@@ -1,0 +1,106 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { expect } from '@std/expect';
+import { ReactiveNode } from './_reactive_node.ts';
+
+class TestReactiveNode extends ReactiveNode {
+  dependencyChanges = 0;
+
+  get hasDependencies(): boolean {
+    return this.hasProducers;
+  }
+
+  read(): void {
+    this.recordAccess();
+  }
+
+  write(): void {
+    this.valueVersion++;
+    this.notifyConsumers();
+  }
+
+  track(read: () => void): void {
+    const previousConsumer = ReactiveNode.setActiveConsumer(this);
+    this.trackingVersion++;
+    try {
+      read();
+    } finally {
+      ReactiveNode.setActiveConsumer(previousConsumer);
+    }
+  }
+
+  dependenciesChanged(): boolean {
+    return this.haveDependenciesChanged();
+  }
+
+  checkForProducerChanges(): void {
+    this.onProducerMayChanged();
+  }
+
+  override onDependencyChange(): void {
+    this.dependencyChanges++;
+  }
+}
+
+class ReadingConsumerNode extends TestReactiveNode {
+  readonly #producer: TestReactiveNode;
+
+  constructor(producer: TestReactiveNode) {
+    super();
+    this.#producer = producer;
+  }
+
+  override onDependencyChange(): void {
+    this.#producer.read();
+  }
+}
+
+class DefaultReactiveNode extends ReactiveNode {
+  notifyDependencyChange(): void {
+    this.onDependencyChange();
+  }
+}
+
+Deno.test('ReactiveNode() should report tracked dependencies', () => {
+  const producer = new TestReactiveNode();
+  const consumer = new TestReactiveNode();
+
+  expect(consumer.hasDependencies).toBe(false);
+  consumer.track(() => producer.read());
+  expect(consumer.hasDependencies).toBe(true);
+});
+
+Deno.test('ReactiveNode.haveDependenciesChanged() should remove stale dependencies', () => {
+  const staleProducer = new TestReactiveNode();
+  const activeProducer = new TestReactiveNode();
+  const consumer = new TestReactiveNode();
+
+  consumer.track(() => staleProducer.read());
+  consumer.track(() => activeProducer.read());
+
+  expect(consumer.dependenciesChanged()).toBe(false);
+
+  staleProducer.write();
+  expect(consumer.dependencyChanges).toBe(0);
+  expect(consumer.hasDependencies).toBe(true);
+});
+
+Deno.test('ReactiveNode.recordAccess() should reject reads during notification', () => {
+  const producer = new TestReactiveNode();
+  const consumer = new ReadingConsumerNode(producer);
+  consumer.track(() => producer.read());
+
+  expect(() => producer.write()).toThrow('Cannot read signals during notification phase.');
+});
+
+Deno.test('ReactiveNode.onProducerMayChanged() should default to a no-op', () => {
+  const node = new TestReactiveNode();
+
+  expect(() => node.checkForProducerChanges()).not.toThrow();
+});
+
+Deno.test('ReactiveNode.onDependencyChange() should default to a no-op', () => {
+  const node = new DefaultReactiveNode();
+
+  expect(() => node.notifyDependencyChange()).not.toThrow();
+});

--- a/reactivity/deno.jsonc
+++ b/reactivity/deno.jsonc
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://jsr.io/schema/config-file.v1.json",
+  "name": "@fragment/reactivity",
+  "version": "1.0.0",
+  "description": "🎯 Seamlessly manage reactive state with signals, enabling automatic updates and fine-grained reactivity across your application.",
+  "keywords": [
+    "deno",
+    "signal",
+    "store",
+    "reactive",
+    "reactivity",
+    "atomic",
+    "state",
+    "global"
+  ],
+  "license": "Apache-2.0",
+  "author": "Deft+",
+  "homepage": "https://github.com/deft-plus/reactivity#README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/deft-plus/reactivity.git"
+  },
+  "imports": {
+    "@std/async": "jsr:@std/async@^1.5.0",
+    "@std/expect": "jsr:@std/expect@^1.0.20",
+    "@std/testing": "jsr:@std/testing@^1.0.20"
+  },
+  "exports": {
+    ".": "./mod.ts"
+  }
+}

--- a/reactivity/effect.ts
+++ b/reactivity/effect.ts
@@ -1,0 +1,275 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the implementation for the {@link effect} function.
+ *
+ * A reactive effect is a function that runs when changes are detected in its dependencies. It is
+ * used to create side effects in a reactive graph. When a reactive effect is created, it is
+ * scheduled to run whenever its dependencies change.
+ *
+ * @example Usage
+ * ```ts
+ * const effectRef = effect(() => {
+ *   console.log('Signal changed:', signal());
+ * });
+ *
+ * effectRef.destroy();
+ *
+ * // Manually destroy all effects.
+ * effect.resetEffects();
+ * ```
+ *
+ * @example Usage with initial execution
+ * ```ts
+ * // Run the effect one initial time and then re-schedule it on changes.
+ * const effectRef = effect.initial(() => {
+ *   console.log('Signal changed and run first time:', signal());
+ * });
+ *
+ * effectRef.destroy();
+ * ```
+ *
+ * @example Usage with dispose
+ * ```ts
+ * {
+ *   // Run the effect one initial time and then re-schedule it on changes.
+ *   using effectRef = effect(() => {
+ *     console.log('Signal changed and run first time:', signal());
+ *
+ *     return () => console.log('Effect disposed');
+ *   });
+ * } // Logs: "Effect disposed".
+ * ```
+ *
+ * @module
+ */
+
+import { ReactiveNode } from './_reactive_node.ts';
+
+/**
+ * Default no-op cleanup function.
+ */
+const NOOP_CLEANUP: EffectCleanup = () => {};
+
+/**
+ * Creates a reactive effect that runs the given callback function when changes are detected in its
+ * dependencies.
+ *
+ * It also provides a way to manually destroy all effects.
+ *
+ * @example Usage
+ * ```ts
+ * const effectRef = effect(() => {
+ *   console.log('Signal changed:', signal());
+ * });
+ *
+ * effectRef.destroy();
+ *
+ * // Manually destroy all effects.
+ * effect.resetEffects();
+ * ```
+ *
+ * @param callback - The callback function ({@link EffectCallback}) to execute when changes are
+ * detected.
+ * @returns A reference ({@link EffectRef}) to the effect that can be manually destroyed.
+ */
+export function effect(callback: EffectCallback): EffectRef {
+  const watch = new EffectImpl(callback);
+  return watch.effect();
+}
+
+/**
+ *  Creates a reactive effect that runs the given callback function immediately and then
+ * re-schedules it on changes in its dependencies.
+ *
+ * @example Usage
+ * ```ts
+ * // Run the effect one initial time and then re-schedule it on changes.
+ * const effectRef = effect.initial(() => {
+ *   console.log('Signal changed and run first time:', signal());
+ * });
+ *
+ * effectRef.destroy();
+ * ```
+ *
+ * @param callback - The callback function ({@link EffectCallback}) to execute when changes are
+ * detected.
+ * @returns A reference ({@link EffectRef}) to the effect that can be manually destroyed.
+ */
+effect.initial = function (callback: EffectCallback): EffectRef {
+  const watch = new EffectImpl(callback);
+  return watch.effect(true);
+};
+
+/** Stop all active effects. */
+effect.resetEffects = (): void => EffectImpl.resetEffects();
+
+/**
+ * Watches a reactive expression and schedules it to re-run when dependencies change.
+ * @internal
+ */
+class EffectImpl extends ReactiveNode {
+  /** Callback executed by this effect. */
+  readonly #callback: EffectCallback;
+
+  constructor(callback: EffectCallback) {
+    super();
+    this.#callback = callback;
+  }
+
+  /** Set of all active effects. */
+  static #activeEffects = new Set<EffectImpl>();
+
+  /** Set of effects scheduled for execution. */
+  static #executionQueue = new Set<EffectImpl>();
+
+  /** Promise that resolves when the execution queue is empty. */
+  static #pendingQueue: PromiseWithResolvers<void> | null = null;
+
+  /** Property to track if this watch is dirty and needs to be re-scheduled. */
+  #dirty = false;
+
+  /** Property to track the current tracking version. */
+  #cleanupFn = NOOP_CLEANUP;
+
+  /** Whether this effect has already been destroyed. */
+  #destroyed = false;
+
+  /** Stop all active effects. */
+  static resetEffects(): void {
+    for (const effect of EffectImpl.#activeEffects) {
+      effect.#destroy();
+    }
+  }
+
+  /** Called when a dependency may have changed. */
+  override onDependencyChange(): void {
+    this.#notify();
+  }
+
+  /**
+   * Get the effect reference.
+   *
+   * @returns A reference to the effect ({@link EffectRef}).
+   */
+  effect(initial = false): EffectRef {
+    EffectImpl.#activeEffects.add(this);
+
+    if (initial) {
+      this.#run();
+    } else {
+      // Schedule the effect to run.
+      this.#notify();
+    }
+
+    return {
+      destroy: () => this.#destroy(),
+      [Symbol.dispose]: () => {
+        this.#destroy();
+      },
+    };
+  }
+
+  /** Destroy this effect and run its cleanup function once. */
+  #destroy(): void {
+    if (this.#destroyed) {
+      return;
+    }
+
+    this.#destroyed = true;
+    EffectImpl.#activeEffects.delete(this);
+    EffectImpl.#executionQueue.delete(this);
+    this.#cleanup();
+  }
+
+  /** Notify that this watch needs to be re-scheduled. */
+  #notify(): void {
+    if (!this.#dirty) {
+      this.#schedule();
+    }
+
+    this.#dirty = true;
+  }
+
+  /**
+   * Executes the reactive expression within the context of this `Watch` instance. Should be called
+   * by the scheduling function when `Watch.notify()` is triggered.
+   */
+  #run(): void {
+    this.#dirty = false;
+
+    if (this.trackingVersion !== 0 && !this.haveDependenciesChanged()) {
+      return;
+    }
+
+    const previousConsumer = ReactiveNode.setActiveConsumer(this);
+    this.trackingVersion++;
+
+    try {
+      this.#cleanupFn();
+      this.#cleanupFn = this.#callback() ?? NOOP_CLEANUP;
+    } finally {
+      ReactiveNode.setActiveConsumer(previousConsumer);
+    }
+  }
+
+  /** Run the cleanup function. */
+  #cleanup(): void {
+    const cleanupFn = this.#cleanupFn;
+    this.#cleanupFn = NOOP_CLEANUP;
+    cleanupFn();
+  }
+
+  /** Queue an effect for execution. */
+  #schedule(): void {
+    if (EffectImpl.#executionQueue.has(this) || !EffectImpl.#activeEffects.has(this)) {
+      return;
+    }
+
+    EffectImpl.#executionQueue.add(this);
+
+    if (EffectImpl.#pendingQueue === null) {
+      Promise.resolve().then(this.#executeQueue);
+      EffectImpl.#pendingQueue = Promise.withResolvers();
+    }
+  }
+
+  /** Execute all queued effects. */
+  #executeQueue(): void {
+    for (const watch of EffectImpl.#executionQueue) {
+      EffectImpl.#executionQueue.delete(watch);
+      watch.#run();
+    }
+
+    EffectImpl.#pendingQueue?.resolve();
+    EffectImpl.#pendingQueue = null;
+  }
+}
+
+/** Cleanup function for a watch. */
+export type EffectCleanup = () => void;
+
+/** Callback for the `effect()` function, called when changes are detected. */
+export type EffectCallback = () => void | EffectCleanup;
+
+/** Reference to the reactive effect created. */
+export interface EffectRef {
+  /** Stop the effect and remove it from execution. */
+  destroy: () => void;
+  /** Dispose of the effect and clean up all event listeners. */
+  [Symbol.dispose]: () => void;
+}
+
+/**
+ * Function that takes a callback and calls it when changes are detected in its dependencies. Then
+ * returns a reference to a reactive effect that can be manually destroyed.
+ */
+export type EffectHandler = (callback: EffectCallback) => EffectRef;
+
+/** A factory function for creating, stopping, and resetting effects. */
+export interface EffectFactory extends EffectHandler {
+  /** Stop all active effects. */
+  resetEffects: () => void;
+  /** Immediately run the effect and then re-schedule it on changes. */
+  initial: EffectHandler;
+}

--- a/reactivity/effect_test.ts
+++ b/reactivity/effect_test.ts
@@ -1,0 +1,151 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { expect } from '@std/expect';
+
+import { delay } from '@std/async';
+
+import { effect } from './effect.ts';
+import { memoSignal } from './memo.ts';
+import { signal } from './signal.ts';
+
+Deno.test('effect() should listen for signal changes and trigger effects', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
+
+  const effectRef = effect(() => {
+    changes.push(value());
+  });
+
+  expect(changes).toEqual([]);
+
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([1]);
+
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1, 2]);
+
+  effectRef.destroy();
+});
+
+Deno.test('EffectRef.destroy() should stop the effect', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
+
+  const effectRef = effect(() => {
+    changes.push(value());
+  });
+
+  expect(changes).toEqual([]);
+
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([1]);
+
+  effectRef.destroy();
+
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1]);
+});
+
+Deno.test('EffectRef.destroy() should be idempotent', () => {
+  let cleanupCalls = 0;
+  const effectRef = effect.initial(() => () => cleanupCalls++);
+
+  effectRef.destroy();
+  effectRef.destroy();
+  effectRef[Symbol.dispose]();
+
+  expect(cleanupCalls).toBe(1);
+});
+
+Deno.test('EffectRef[Symbol.dispose]() should stop the effect when it leaves scope', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
+
+  {
+    using _effectRef = effect(() => {
+      changes.push(value());
+    });
+
+    expect(changes).toEqual([]);
+
+    value.set(1);
+    await delay(1);
+    expect(changes).toEqual([1]);
+  }
+
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1]);
+});
+
+Deno.test('effect.initial() should run the effect immediately', async () => {
+  const value = signal(0);
+  const changes = [] as number[];
+
+  const effectRef = effect.initial(() => {
+    changes.push(value());
+  });
+
+  expect(changes).toEqual([0]);
+  await delay(1);
+  expect(changes).toEqual([0]);
+
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([0, 1]);
+
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([0, 1, 2]);
+
+  effectRef.destroy();
+});
+
+Deno.test('effect() should skip execution when dependency values do not change', async () => {
+  const source = signal(1);
+  const parity = memoSignal(() => source() % 2);
+  const changes: number[] = [];
+  const effectRef = effect(() => {
+    changes.push(parity());
+  });
+
+  await delay(1);
+  expect(changes).toEqual([1]);
+
+  source.set(3);
+  await delay(1);
+  expect(changes).toEqual([1]);
+
+  effectRef.destroy();
+});
+
+Deno.test('effect.resetEffects() should stop all active effects', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
+  let cleanupCalls = 0;
+
+  const effectRef = effect(() => {
+    changes.push(value());
+    return () => cleanupCalls++;
+  });
+
+  expect(changes).toEqual([]);
+
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([1]);
+
+  effect.resetEffects();
+  expect(cleanupCalls).toBe(1);
+
+  effectRef.destroy();
+  expect(cleanupCalls).toBe(1);
+
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1]);
+});

--- a/reactivity/memo.ts
+++ b/reactivity/memo.ts
@@ -1,0 +1,240 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the implementation for the {@link memoSignal} function.
+ *
+ * A memoized signal is a signal that computes the value based on dependencies. The value is cached
+ * until dependencies change.
+ *
+ * @example Usage
+ * ```ts
+ * const counter = signal(1);
+ * const doubleCounter = memoSignal(() => counter() * 2);
+ *
+ * console.log(doubleCounter()); // Logs: "2".
+ *
+ * // The value is cached until dependencies change.
+ * counter.set(2);
+ *
+ * console.log(doubleCounter()); // Logs: "4".
+ * ```
+ *
+ * @module
+ */
+
+import {
+  defaultEquals,
+  markAsSignal,
+  type MemoizedSignal,
+  type MemoizedSignalOptions,
+} from './_api.ts';
+import { resolveSignalLog } from './_logging.ts';
+import { ReactiveNode } from './_reactive_node.ts';
+import { untrackedSignal } from './untracked.ts';
+
+/**
+ * Symbol for a memoized value that hasn't been computed yet.
+ * @internal
+ */
+const UNSET = Symbol('UNSET');
+
+/**
+ * Symbol indicating a computation is in progress. Used to detect cycles.
+ * @internal
+ */
+const COMPUTING = Symbol('COMPUTING');
+
+/**
+ * Symbol indicating a computation failed. The error is cached until the value is recomputed.
+ * @internal
+ */
+const ERRORED = Symbol('ERRORED');
+
+/**
+ * Creates a memoized signal that computes the value and caches it until dependencies change.
+ *
+ * @example Usage
+ * ```ts
+ * const counter = signal(1);
+ * const doubleCounter = memoSignal(() => counter() * 2);
+ *
+ * console.log(doubleCounter()); // Logs: "2".
+ *
+ * // The value is cached until dependencies change.
+ * counter.set(2);
+ *
+ * console.log(doubleCounter()); // Logs: "4".
+ * ```
+ *
+ * @template T - The type of the value returned by the signal.
+ * @param compute - Computation function to derive the value.
+ * @param options - Options for the memoized signal ({@link MemoizedSignalOptions}).
+ * @returns A memoized signal ({@link MemoizedSignal}) that computes the value on demand.
+ */
+export function memoSignal<T>(
+  compute: () => T,
+  options?: MemoizedSignalOptions<T>,
+): MemoizedSignal<T> {
+  const {
+    name = `memo_signal_${Math.random().toString(36).slice(2)}`,
+    log = resolveSignalLog(options?.log),
+    equal = defaultEquals,
+    subscribe = () => {},
+  } = options ?? {};
+
+  const node = new MemoizedSignalImp(compute, { name, log, equal, subscribe });
+
+  return markAsSignal('memoized', node.signal.bind(node), {
+    identifier: name,
+    untracked: node.untracked.bind(node),
+    toString: node.toString.bind(node),
+  });
+}
+
+/**
+ * A computation node that derives a value from a reactive expression.
+ * @internal
+ */
+class MemoizedSignalImp<T> extends ReactiveNode {
+  /** Computation used to derive the memoized value. */
+  readonly #compute: () => T;
+
+  /** Fully resolved memoized signal options. */
+  readonly #options: Required<MemoizedSignalOptions<T>>;
+
+  constructor(compute: () => T, options: Required<MemoizedSignalOptions<T>>) {
+    super();
+    this.#compute = compute;
+    this.#options = options;
+  }
+
+  /** Current value of the computation or one of the special symbols. */
+  #value: MemoizedValue<T> = UNSET;
+
+  /** Error from the last computation if it failed. */
+  #error: unknown = null;
+
+  /** Flag indicating if the value is stale. */
+  #stale = true;
+
+  /** Called when a dependency may have changed. */
+  override onDependencyChange(): void {
+    if (this.#stale) {
+      return; // If already stale, no need to reprocess. This also allow batching changes.
+    }
+
+    this.#stale = true; // Mark the value as stale.
+    this.notifyConsumers(); // Notify consumers about potential change.
+  }
+
+  /** Called when a consumer checks if the producer's value has changed. */
+  override onProducerMayChanged(): void {
+    if (!this.#stale) {
+      return; // If not stale, no update needed.
+    }
+
+    // If dependencies haven't changed, resolve stale.
+    if (
+      this.#value !== UNSET &&
+      this.#value !== COMPUTING &&
+      !this.haveDependenciesChanged()
+    ) {
+      this.#stale = false;
+      return;
+    }
+
+    // Recompute the value as it is stale.
+    this.#recomputeValue();
+  }
+
+  /**
+   * Get the current value of the signal without creating a dependency.
+   *
+   * @returns The current value of the signal without creating a dependency.
+   */
+  untracked(): T {
+    return untrackedSignal(() => this.signal()); // Use untracked utility to access value.
+  }
+
+  /**
+   * Get the current value of the signal.
+   *
+   * @returns The current value of the signal.
+   */
+  signal(): T {
+    this.onProducerMayChanged();
+    this.recordAccess();
+
+    if (this.#value === ERRORED) {
+      throw this.#error;
+    }
+
+    return this.#value as T;
+  }
+
+  /** Recomputes the value if needed. */
+  #recomputeValue(): void {
+    if (this.#value === COMPUTING) {
+      throw new Error('Cycle detected in computations.'); // Prevent infinite loops.
+    }
+
+    const oldValue = this.#value;
+    this.#value = COMPUTING;
+
+    this.trackingVersion++;
+    const previousConsumer = ReactiveNode.setActiveConsumer(this);
+    let newValue: MemoizedValue<T>;
+
+    try {
+      newValue = this.#compute();
+    } catch (err) {
+      newValue = ERRORED;
+      this.#error = err;
+    } finally {
+      ReactiveNode.setActiveConsumer(previousConsumer);
+    }
+
+    this.#stale = false;
+
+    // Update value if there is a change.
+    if (
+      oldValue !== UNSET &&
+      oldValue !== ERRORED &&
+      newValue !== ERRORED &&
+      this.#options.equal(oldValue, newValue)
+    ) {
+      this.#value = oldValue; // Keep old value if new value is equivalent.
+      return;
+    }
+
+    this.#value = newValue;
+    this.valueVersion++;
+
+    if (this.#options.log) {
+      super.log({
+        type: 'MemoSignal',
+        name: this.#options.name,
+        newValue: this.#value,
+        oldValue,
+      });
+    }
+
+    this.#options.subscribe(this.#value as T, (oldValue === UNSET ? undefined : oldValue) as T);
+  }
+
+  /**
+   * Used to show the signal in console logs easily.
+   *
+   * @returns A string representation of the signal.
+   */
+  override toString(): string {
+    return `[MemoSignal: ${JSON.stringify(this.signal())}]`;
+  }
+}
+
+/**
+ * Possible values for a memoized signal.
+ *
+ * @template T - The type of the value returned by the signal.
+ */
+type MemoizedValue<T> = T | typeof UNSET | typeof COMPUTING | typeof ERRORED;

--- a/reactivity/memo_test.ts
+++ b/reactivity/memo_test.ts
@@ -1,0 +1,257 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { assertSpyCalls, stub } from '@std/testing/mock';
+import { expect } from '@std/expect';
+
+import { delay } from '@std/async';
+
+import type { MemoizedSignal } from './_api.ts';
+import { memoSignal } from './memo.ts';
+import { signal } from './signal.ts';
+import { effect } from './effect.ts';
+
+Deno.test('memoSignal() should create a memoized signal', () => {
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
+
+  expect(doubleCounter()).toBe(0);
+
+  counter.set(1);
+
+  expect(doubleCounter()).toBe(2);
+});
+
+Deno.test('memoSignal() should expose its configured name as the identifier', () => {
+  const value = memoSignal(() => 42, { name: 'answer' });
+
+  expect(value.identifier).toBe('answer');
+});
+
+Deno.test('memoSignal() should support a custom equality function', () => {
+  const counter = signal(0);
+
+  // Can only be set to a value greater than or equal to the current value.
+  const doubleCounter = memoSignal(
+    () => counter() * 2,
+    { equal: (a, b) => a >= b },
+  );
+
+  expect(doubleCounter()).toBe(0);
+
+  counter.set(1);
+
+  expect(doubleCounter()).toBe(2);
+
+  counter.set(4);
+
+  expect(doubleCounter()).toBe(8);
+
+  counter.set(2);
+
+  expect(doubleCounter()).toBe(8);
+
+  counter.set(1);
+
+  expect(doubleCounter()).toBe(8);
+});
+
+Deno.test('memoSignal() should schedule on dependencies (memoized) change', async () => {
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
+
+  const effectCounter = [] as number[];
+
+  effect(() => {
+    effectCounter.push(doubleCounter());
+  });
+
+  await delay(1);
+  expect(effectCounter).toStrictEqual([0]);
+
+  counter.set(1);
+
+  await delay(1);
+  expect(effectCounter).toStrictEqual([0, 2]);
+});
+
+Deno.test('memoSignal() should apply its configuration options', () => {
+  using consoleStub = stub(console, 'log', (_) => {});
+
+  const newCalled = [] as number[];
+  const oldCalled = [] as number[];
+  const counter = signal(0);
+
+  const doubleCounter = memoSignal(
+    () => counter() * 2,
+    {
+      name: 'doubleCounter',
+      log: true,
+      subscribe: (newValue, oldValue) => {
+        newCalled.push(newValue);
+        oldCalled.push(oldValue);
+      },
+    },
+  );
+
+  expect(doubleCounter()).toBe(0);
+
+  expect(newCalled).toStrictEqual([0]);
+  expect(oldCalled).toStrictEqual([undefined]);
+
+  counter.set(1);
+  expect(doubleCounter()).toBe(2);
+  expect(newCalled).toStrictEqual([0, 2]);
+  expect(oldCalled).toStrictEqual([undefined, 0]);
+
+  counter.set(23);
+  expect(doubleCounter()).toBe(46);
+  expect(newCalled).toStrictEqual([0, 2, 46]);
+  expect(oldCalled).toStrictEqual([undefined, 0, 2]);
+
+  counter.set(23);
+  expect(doubleCounter()).toBe(46);
+  expect(newCalled).toStrictEqual([0, 2, 46]);
+  expect(oldCalled).toStrictEqual([undefined, 0, 2]);
+
+  assertSpyCalls(consoleStub, 9); // 9 calls since each log is called 3 times.
+});
+
+Deno.test('memoSignal() should be able to keep track of multiple dependencies and batch changes', () => {
+  const counter = signal(0);
+  const counter2 = signal(0);
+
+  const changes = [] as number[];
+
+  const doubleCounter = memoSignal(() => {
+    const value = counter() * 2 + counter2();
+    changes.push(value);
+    return value;
+  });
+
+  expect(doubleCounter()).toBe(0);
+
+  counter.set(1);
+  counter2.set(2);
+
+  expect(doubleCounter()).toBe(4);
+  expect(changes).toStrictEqual([0, 4]);
+});
+
+Deno.test('memoSignal() should throw on a circular dependency', () => {
+  let circularCounter: MemoizedSignal<number> | null = null;
+
+  const counter = memoSignal(() => (circularCounter?.() ?? 0) * 2);
+  circularCounter = memoSignal(() => counter());
+
+  expect(() => counter()).toThrow();
+});
+
+Deno.test('MemoizedSignal.untracked() should not track dependencies', () => {
+  const changes: number[] = [];
+
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
+
+  effect(() => {
+    changes.push(doubleCounter.untracked());
+  });
+
+  counter.set(1);
+
+  expect(changes).toStrictEqual([]);
+
+  counter.set(2);
+
+  expect(changes).toStrictEqual([]);
+});
+
+Deno.test('memoSignal() should update conditional dependencies', () => {
+  const counter = signal(0);
+  const counter2 = signal(0);
+  const condition = signal(false);
+
+  const conditionalSignal = memoSignal(() => condition() ? counter() : counter2());
+
+  expect(conditionalSignal()).toBe(0);
+
+  counter.set(23);
+  expect(conditionalSignal()).toBe(0);
+
+  condition.set(true);
+  expect(conditionalSignal()).toBe(23);
+
+  counter2.set(2);
+  expect(conditionalSignal()).toBe(23);
+});
+
+Deno.test('memoSignal() should not propagate equivalent values', () => {
+  const counter = signal(10);
+  const counter2 = signal(10);
+
+  const doubleCounter = memoSignal(() => counter() + counter2());
+
+  expect(doubleCounter()).toBe(20);
+
+  counter.set(7);
+  counter2.set(13);
+
+  expect(doubleCounter()).toBe(20);
+});
+
+Deno.test('memoSignal() should cache exceptions thrown until computed gets dirty again', () => {
+  const counter = signal(0);
+  const errorCounter = memoSignal(() => {
+    if (counter() === 0) {
+      throw new Error('Counter is zero');
+    }
+
+    return counter();
+  });
+
+  expect(() => errorCounter()).toThrow('Counter is zero');
+
+  counter.set(1);
+
+  expect(errorCounter()).toBe(1);
+});
+
+Deno.test("memoSignal() should not update consumers when dependencies don't change", () => {
+  const source = signal(0);
+  const isEven = memoSignal(() => source() % 2 === 0);
+  let updateCounter = 0;
+  const updateTracker = memoSignal(() => {
+    isEven();
+    return updateCounter++;
+  });
+
+  updateTracker();
+  expect(updateCounter).toEqual(1);
+
+  source.set(1);
+  updateTracker();
+  expect(updateCounter).toEqual(2);
+
+  // Setting the counter to another odd value should not trigger `updateTracker` to update.
+  source.set(3);
+  updateTracker();
+  expect(updateCounter).toEqual(2);
+
+  source.set(4);
+  updateTracker();
+  expect(updateCounter).toEqual(3);
+});
+
+Deno.test('memoSignal() should support signal creation during computation', () => {
+  const doubleCounter = memoSignal(() => {
+    const counter = signal(1);
+    return counter() * 2;
+  });
+
+  expect(doubleCounter()).toBe(2);
+});
+
+Deno.test('MemoizedSignal.toString() should return its string representation', () => {
+  const counter = signal(1);
+  const doubleCounter = memoSignal(() => counter() * 2);
+  expect(doubleCounter + '').toBe('[MemoSignal: 2]');
+});

--- a/reactivity/mod.ts
+++ b/reactivity/mod.ts
@@ -1,0 +1,22 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+export {
+  type MemoizedSignal,
+  type MemoizedSignalOptions,
+  type ReadonlySignal,
+  type Signal,
+  type SignalOptions,
+  type SignalType,
+  type WritableSignal,
+} from './_api.ts';
+export {
+  effect,
+  type EffectCallback,
+  type EffectCleanup,
+  type EffectHandler,
+  type EffectRef,
+} from './effect.ts';
+export { memoSignal } from './memo.ts';
+export { type PromiseValue, toSignal } from './to_signal.ts';
+export { signal } from './signal.ts';
+export { type Store, store, type StoreValues, type ValidStore } from './store.ts';

--- a/reactivity/signal.ts
+++ b/reactivity/signal.ts
@@ -1,0 +1,348 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the implementation for the {@link signal} function.
+ *
+ * A signal is a reactive value that can be read and watched for changes. This function creates a
+ * signal that can be set or updated directly.
+ *
+ * @example Usage
+ * ```ts
+ * const counter = signal(0);
+ *
+ * console.log(counter()); // Logs: "0".
+ *
+ * counter.set(1);
+ *
+ * console.log(counter()); // Logs: "1".
+ *
+ * counter.update((value) => value + 1);
+ *
+ * console.log(counter()); // Logs: "2".
+ *
+ * counter.mutate((value) => value++);
+ *
+ * console.log(counter()); // Logs: "3".
+ * ```
+ *
+ * @example Usage with options
+ * ```ts
+ * const counter = signal(0, {
+ *   id: 'counter',
+ *   log: true,
+ *   equal: (a, b) => a === b,
+ *   onChange: (value) => console.log(`Counter changed to: ${value}`),
+ * });
+ *
+ * console.log(counter()); // Logs: "0".
+ *
+ * counter.set(1); // Logs: "Counter changed to: 1".
+ *
+ * console.log(counter()); // Logs: "1".
+ *
+ * counter.set(1); // No log.
+ * ```
+ *
+ * @example Usage with events
+ * ```ts
+ * {
+ *   using counter = signal(0, {
+ *     allowEvents: true,
+ *     onDispose: () => console.log('Cleanup logic'), // Cleanup logic.
+ *   });
+ *
+ *   console.log(counter()); // Logs: "0".
+ *
+ *   counter.set(1);
+ *
+ *   console.log(counter()); // Logs: "1".
+ *
+ *   dispatchEvent(new CustomEvent(counter.identifier, { detail: 2 }));
+ *
+ *   console.log(counter()); // Logs: "2".
+ * } // Logs: "Cleanup logic".
+ * ```
+ *
+ * @module
+ */
+
+import type { WritableEventSignal } from './_api.ts';
+import {
+  defaultEquals,
+  markAsSignal,
+  type ReadonlySignal,
+  type SignalEventOptions,
+  type SignalOptions,
+  type WritableSignal,
+} from './_api.ts';
+import { resolveSignalLog } from './_logging.ts';
+import { ReactiveNode } from './_reactive_node.ts';
+import { untrackedSignal } from './untracked.ts';
+
+/**
+ * Create a signal that can be set or updated directly.
+ *
+ * @example Usage
+ * ```ts
+ * const counter = signal(0);
+ *
+ * console.log(counter()); // Logs: "0".
+ *
+ * counter.set(1);
+ *
+ * console.log(counter()); // Logs: "1".
+ *
+ * counter.update((value) => value + 1);
+ *
+ * console.log(counter()); // Logs: "2".
+ *
+ * counter.mutate((value) => value++);
+ *
+ * console.log(counter()); // Logs: "3".
+ * ```
+ *
+ * @example Usage with options
+ * ```ts
+ * const counter = signal(0, {
+ *   id: 'counter',
+ *   log: true,
+ *   equal: (a, b) => a === b,
+ *   onChange: (value) => console.log(`Counter changed to: ${value}`),
+ * });
+ *
+ * console.log(counter()); // Logs: "0".
+ *
+ * counter.set(1); // Logs: "Counter changed to: 1".
+ *
+ * console.log(counter()); // Logs: "1".
+ *
+ * counter.set(1); // No log.
+ * ```
+ *
+ * @template T - The type of the signal value.
+ * @param initialValue - The initial value of the signal.
+ * @param options - The options for the signal.
+ * @returns A writable signal.
+ */
+export function signal<T>(
+  initialValue: T,
+  options?: SignalOptions<T>,
+): WritableSignal<T>;
+
+/**
+ * Create a signal that can be set or updated directly and that receives events.
+ *
+ * @example Usage
+ * ```ts
+ * {
+ *   using counter = signal(0, {
+ *     allowEvents: true,
+ *     onDispose: () => console.log('Cleanup logic'), // Cleanup logic.
+ *   });
+ *
+ *   console.log(counter()); // Logs: "0".
+ *
+ *   counter.set(1);
+ *
+ *   console.log(counter()); // Logs: "1".
+ *
+ *   dispatchEvent(new CustomEvent(counter.identifier, { detail: 2 }));
+ *
+ *   console.log(counter()); // Logs: "2".
+ * } // Logs: "Cleanup logic".
+ * ```
+ *
+ * @template T - The type of the signal value.
+ * @param initialValue - The initial value of the signal.
+ * @param options - The options for the signal.
+ * @returns A writable signal.
+ */
+export function signal<T>(
+  initialValue: T,
+  options?: SignalEventOptions<T>,
+): WritableEventSignal<T>;
+
+/**
+ * Create a signal that can be set or updated directly.
+ *
+ * @template T - The type of the signal value.
+ * @param initialValue - The initial value of the signal.
+ * @param options - The options for the signal.
+ * @returns A writable signal.
+ */
+export function signal<T>(
+  initialValue: T,
+  options?: SignalEventOptions<T> | SignalOptions<T>,
+): WritableSignal<T> | WritableEventSignal<T> {
+  const {
+    name = `signal_${Math.random().toString(36).slice(2)}`,
+    log = resolveSignalLog(options?.log),
+    equal = defaultEquals,
+    subscribe = () => {},
+    allowEvents = false as true,
+    onDispose = () => {},
+  } = (options ?? {}) as SignalEventOptions<T>;
+
+  const node = new WritableSignalImpl(initialValue, {
+    name,
+    log,
+    equal,
+    subscribe,
+    allowEvents,
+    onDispose,
+  });
+
+  return markAsSignal('writable', node.signal.bind(node), {
+    identifier: name,
+    set: node.set.bind(node),
+    update: node.update.bind(node),
+    mutate: node.mutate.bind(node),
+    readonly: node.readonly.bind(node),
+    untracked: node.untracked.bind(node),
+    toString: node.toString.bind(node),
+    [Symbol.dispose]: node.dispose.bind(node),
+  });
+}
+
+/**
+ * A signal that can be set or updated directly.
+ * @internal
+ */
+class WritableSignalImpl<T> extends ReactiveNode {
+  /** Current signal value. */
+  #value: T;
+
+  /** Fully resolved signal options. */
+  readonly #options: Required<SignalEventOptions<T>>;
+
+  constructor(value: T, options: Required<SignalEventOptions<T>>) {
+    super();
+    this.#value = value;
+    this.#options = options;
+    if (this.#options.allowEvents) {
+      this.#listener = (event) => this.set((event as CustomEvent).detail);
+
+      addEventListener(options.name, this.#listener);
+    }
+  }
+
+  /** Listener for events if allowed. */
+  #listener: ((event: Event) => void) | null = null;
+
+  /** The current value of the signal as read-only. */
+  #readonlySignal?: ReadonlySignal<T>;
+
+  /**
+   * Set a new value for the signal and notify consumers if changed.
+   *
+   * @param newValue - The new value to set.
+   */
+  set(newValue: T): void {
+    if (!this.#options.equal(this.#value, newValue)) {
+      const oldValue = this.#value;
+      this.#value = newValue;
+      this.valueVersion++;
+      this.notifyConsumers();
+
+      if (this.#options.log) {
+        super.log({
+          type: 'Signal',
+          name: this.#options.name,
+          newValue: this.#value,
+          oldValue,
+        });
+      }
+
+      this.#options.subscribe?.(this.#value, oldValue);
+    }
+  }
+
+  /**
+   * Update the signal's value using the provided function.
+   *
+   * @param updater - The function to update the value.
+   */
+  update(updater: (value: T) => T): void {
+    this.set(updater(this.#value));
+  }
+
+  /**
+   * Apply a function to mutate the signal's value in-place.
+   *
+   * @param mutator - The function to mutate the value.
+   */
+  mutate(mutator: (value: T) => void): void {
+    const oldValue = this.#value;
+    mutator(this.#value);
+    this.valueVersion++;
+    this.notifyConsumers();
+
+    if (this.#options.log) {
+      super.log({
+        type: 'Signal',
+        name: this.#options.name,
+        newValue: this.#value,
+        oldValue,
+      });
+    }
+
+    this.#options.subscribe?.(this.#value, oldValue);
+  }
+
+  /**
+   * Returns a read-only signal derived from this signal.
+   *
+   * @returns A read-only signal.
+   */
+  readonly(): ReadonlySignal<T> {
+    if (!this.#readonlySignal) {
+      this.#readonlySignal = markAsSignal<ReadonlySignal<T>>(
+        'readonly',
+        () => this.signal(),
+        {
+          identifier: `${this.#options.name}_readonly_${Math.random().toString(36).slice(2)}`,
+          untracked: () => this.untracked(),
+        },
+      );
+    }
+
+    return this.#readonlySignal;
+  }
+
+  /**
+   * Returns an untracked signal derived from this signal.
+   *
+   * @returns An untracked signal.
+   */
+  untracked(): T {
+    return untrackedSignal(() => this.signal());
+  }
+
+  /**
+   * Returns the current value of the signal.
+   *
+   * @returns The current value of the signal.
+   */
+  signal(): T {
+    this.recordAccess();
+    return this.#value;
+  }
+
+  /** Dispose of the signal and remove any event listeners. */
+  dispose(): void {
+    if (this.#options.allowEvents && this.#listener) {
+      this.#options.onDispose?.();
+
+      removeEventListener(this.#options.name, this.#listener);
+    }
+  }
+
+  /**
+   * Used to show the signal in console logs easily.
+   *
+   * @returns A string representation of the signal.
+   */
+  override toString(): string {
+    return `[Signal: ${JSON.stringify(this.signal())}]`;
+  }
+}

--- a/reactivity/signal_test.ts
+++ b/reactivity/signal_test.ts
@@ -1,0 +1,216 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { assertSpyCalls, stub } from '@std/testing/mock';
+import { expect } from '@std/expect';
+
+import type { WritableSignal } from './_api.ts';
+import { signal } from './signal.ts';
+import { effect } from './effect.ts';
+
+type TestingUser = {
+  name: string;
+  age: number;
+};
+
+Deno.test('signal() should create a writable signal with the initial value', () => {
+  const counter = signal(0);
+
+  expect(counter()).toBe(0);
+});
+
+Deno.test('signal() should apply its configuration options', () => {
+  const counter = signal(0, { name: 'counter', log: true });
+
+  expect(counter()).toBe(0);
+});
+
+Deno.test('WritableSignal.set() should replace the current value', () => {
+  const counter = signal(0);
+
+  counter.set(1);
+
+  expect(counter()).toBe(1);
+});
+
+Deno.test('WritableSignal.update() should derive a new value from the current value', () => {
+  const counter = signal(0);
+
+  counter.update((value) => value + 1);
+
+  expect(counter()).toBe(1);
+});
+
+Deno.test('WritableSignal.mutate() should mutate the current value in place', () => {
+  const user = signal<TestingUser>({ name: 'Alice', age: 42 });
+
+  user.mutate((value) => {
+    value.name = 'Bob';
+  });
+
+  expect(user().name).toBe('Bob');
+});
+
+Deno.test('WritableSignal.readonly() should create a readonly signal', () => {
+  const value = signal(0).readonly();
+
+  expect(value()).toBe(0);
+
+  const signalFnKeys = Object.keys(value);
+  const writableKeys = signalFnKeys.find((key) =>
+    key === 'set' || key === 'update' || key === 'mutate'
+  );
+
+  expect(writableKeys).toBe(undefined);
+});
+
+Deno.test('WritableSignal.readonly() should stay synchronized with its source', () => {
+  const privateCounter = signal(0);
+
+  const counter = {
+    mutable: privateCounter,
+    readonly: privateCounter.readonly(),
+  };
+
+  expect(counter.readonly()).toBe(0);
+
+  const signalFnKeys = Object.keys(counter.readonly);
+  const writableKeys = signalFnKeys.find((key) =>
+    key === 'set' || key === 'update' || key === 'mutate'
+  );
+
+  expect(writableKeys).toBe(undefined);
+
+  privateCounter.set(1);
+  expect(counter.readonly()).toBe(1);
+
+  counter.mutable.set(2);
+  expect(counter.readonly()).toBe(2);
+});
+
+Deno.test('signal() should call the subscribe hook after value changes', () => {
+  const called = [] as number[];
+
+  const counter = signal(0, {
+    subscribe: (value) => called.push(value),
+  });
+
+  expect(called).toStrictEqual([]);
+
+  counter.set(1);
+  expect(called).toStrictEqual([1]);
+
+  counter.set(23);
+  expect(called).toStrictEqual([1, 23]);
+
+  counter.set(23);
+  expect(called).toStrictEqual([1, 23]);
+});
+
+Deno.test('signal() should support derived function values', () => {
+  const counter = signal(0);
+  const doubleCounter = () => counter() * 2;
+
+  expect(doubleCounter()).toBe(0);
+
+  counter.set(1);
+
+  expect(doubleCounter()).toBe(2);
+});
+
+Deno.test('signal() should remain readable when passed as a function parameter', () => {
+  const firstName = signal('Alice');
+  const lastName = signal('Smith');
+
+  type Signals = {
+    firstName: WritableSignal<string>;
+    lastName: WritableSignal<string>;
+  };
+
+  const buildDisplayName = ({ firstName, lastName }: Signals) => `${firstName()} ${lastName()}`;
+
+  const displayName = () => buildDisplayName({ firstName, lastName });
+
+  expect(displayName()).toBe('Alice Smith');
+
+  firstName.set('Bob');
+
+  expect(displayName()).toBe('Bob Smith');
+});
+
+Deno.test('WritableSignal.untracked() should not track dependencies', () => {
+  const changes: number[] = [];
+
+  const counter = signal(0);
+  const readonlyCounter = counter.readonly();
+
+  effect(() => {
+    changes.push(counter.untracked());
+    changes.push(readonlyCounter.untracked());
+  });
+
+  counter.set(1);
+
+  expect(changes).toStrictEqual([]);
+
+  counter.set(2);
+
+  expect(changes).toStrictEqual([]);
+});
+
+Deno.test('signal() should update its value from configured events', () => {
+  using counter = signal(0, { allowEvents: true });
+
+  expect(counter()).toBe(0);
+
+  dispatchEvent(new CustomEvent(counter.identifier, { detail: 1 }));
+
+  expect(counter()).toBe(1);
+});
+
+Deno.test('WritableEventSignal[Symbol.dispose]() should remove its event listener', () => {
+  const changes: number[] = [];
+
+  {
+    using counter = signal(0, {
+      name: 'counter_test_2',
+      allowEvents: true,
+      subscribe: (value) => changes.push(value),
+    });
+
+    expect(changes).toStrictEqual([]);
+    expect(counter()).toBe(0);
+
+    dispatchEvent(new CustomEvent('counter_test_2', { detail: 1 }));
+
+    expect(changes).toStrictEqual([1]);
+    expect(counter()).toBe(1);
+  }
+
+  dispatchEvent(new CustomEvent('counter_test_2', { detail: 2 }));
+  expect(changes).toStrictEqual([1]);
+});
+
+Deno.test('WritableSignal.readonly() should create a distinct identifier', () => {
+  const counter = signal(0, { name: 'counter' });
+  const readonlyCounter = counter.readonly();
+
+  expect(counter.identifier).not.toBe(readonlyCounter.identifier);
+});
+
+Deno.test('signal() should log changes', () => {
+  using consoleStub = stub(console, 'log', (_) => {});
+
+  const hello = signal({ hello: 'world' }, { name: 'hello', log: true });
+
+  hello.set({ hello: 'world set' });
+  hello.mutate((value) => {
+    value.hello = 'world mutate';
+  });
+
+  assertSpyCalls(consoleStub, 6); // 6 calls since each log is called 3 times.
+});
+
+Deno.test('WritableSignal.toString() should return its string representation', () => {
+  const counter = signal(1);
+  expect(counter + '').toBe('[Signal: 1]');
+});

--- a/reactivity/store.ts
+++ b/reactivity/store.ts
@@ -1,0 +1,269 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the implementation for the {@link store} function.
+ *
+ * A store is a reactive atomic piece of state that can be read through signals and written through
+ * actions. This function creates a store that can be used to read and write the state.
+ *
+ * @example Usage
+ * ```ts
+ * const counterStore = store(({ get }) => ({
+ *   counter: 0,
+ *   increment: () => get().counter++,
+ *   decrement: () => get().counter--,
+ * }));
+ *
+ * const counterValues = counterStore();
+ *
+ * console.log(counterValues.counter()); // Logs: "0".
+ *
+ * counterValues.increment();
+ *
+ * console.log(counterValues.counter()); // Logs: "1".
+ * ```
+ *
+ * @example Usage with selector
+ * ```ts
+ * const counterStore = store(({ get }) => ({
+ *   counter: 0,
+ *   increment: () => get().counter++,
+ *   decrement: () => get().counter--,
+ * }));
+ *
+ * const counter = counterStore('counter');
+ * const increment = counterStore('increment');
+ *
+ * console.log(counter()); // Logs: "0".
+ *
+ * increment();
+ *
+ * console.log(counter()); // Logs: "1".
+ * ```
+ */
+
+import {
+  isSignal,
+  type MemoizedSignalOptions,
+  type ReadonlySignal,
+  type SignalOptions,
+  type WritableSignal,
+} from './_api.ts';
+import { memoSignal } from './memo.ts';
+import { signal } from './signal.ts';
+
+/**
+ * Creates a reactive atomic piece of state ({@link store}) that can be read through signals and
+ * written through actions.
+ *
+ * @example Usage
+ * ```ts
+ * const counterStore = store(({ get }) => ({
+ *   counter: 0,
+ *   increment: () => get().counter++,
+ *   decrement: () => get().counter--,
+ * }));
+ *
+ * const counterValues = counterStore();
+ *
+ * console.log(counterValues.counter()); // Logs: "0".
+ *
+ * counterValues.increment();
+ *
+ * console.log(counterValues.counter()); // Logs: "1".
+ * ```
+ *
+ * @example Usage with selector
+ * ```ts
+ * const counterStore = store(({ get }) => ({
+ *   counter: 0,
+ *   increment: () => get().counter++,
+ *   decrement: () => get().counter--,
+ * }));
+ *
+ * const counter = counterStore('counter');
+ * const increment = counterStore('increment');
+ *
+ * console.log(counter()); // Logs: "0".
+ *
+ * increment();
+ *
+ * console.log(counter()); // Logs: "1".
+ * ```
+ *
+ * @template T - The type of the store.
+ * @param initializeStoreValues - Function that initializes the store values.
+ * @returns A store that can be used to read and write the state.
+ */
+export function store<T extends ValidStore>(initializeStoreValues: StoreValues<T>): Store<T> {
+  const __id__ = `store_${Math.random().toString(36).slice(2)}`;
+
+  const mutableState = { __id__ } as ReadonlyState<T>;
+  const immutableState = { __id__ } as ReadonlyState<T>;
+  const initialState = initializeStoreValues({ get: () => mutableState as WritableState<T> });
+
+  const stateEntries = Object.entries(initialState);
+
+  for (let index = 0; index < stateEntries.length; index++) {
+    const [stateKey, stateValue] = stateEntries[index];
+
+    // If the value is a function, it's an action / derived value.
+    if (typeof stateValue === 'function') {
+      Object.defineProperty(mutableState, stateKey, { value: stateValue, writable: false });
+      Object.defineProperty(immutableState, stateKey, { value: stateValue, writable: false });
+      continue;
+    }
+
+    // If the value is not a function, it's a signal.
+    const isConfigured = isConfiguredValue(stateValue);
+    const signalValue = (isConfigured ? stateValue.value : stateValue) as T | (() => T);
+    const isComputed = typeof signalValue === 'function';
+
+    const signalConfig = {
+      ...(isConfigured && stateValue.name && { name: stateValue.name }),
+      ...(isConfigured && stateValue.log !== undefined && { log: stateValue.log }),
+      ...(isConfigured && stateValue.equal && { equal: stateValue.equal }),
+      ...(isConfigured && stateValue.subscribe && { subscribe: stateValue.subscribe }),
+    } as SignalOptions<T>;
+
+    // Value assignment to a memoized or normal signal.
+    const valueSignal = isComputed
+      ? memoSignal(signalValue, signalConfig)
+      : signal(signalValue, signalConfig);
+
+    // Value assignment to the mutable and immutable state.
+    Object.defineProperty(mutableState, stateKey, { value: valueSignal, writable: false });
+    Object.defineProperty(immutableState, stateKey, {
+      value: isSignal.writable(valueSignal) ? valueSignal.readonly() : valueSignal,
+      writable: false,
+    });
+  }
+
+  // Function to use the store.
+  function useStore<U extends (keyof T)>(): ReadonlyState<T>[U];
+  function useStore(): ReadonlyState<T>;
+  function useStore<U extends (keyof T)>(selector?: U): ReadonlyState<T>[U] | ReadonlyState<T> {
+    return selector === undefined ? immutableState : immutableState[selector];
+  }
+
+  return useStore;
+}
+
+/**
+ * Utility function to check if a value is a configured value.
+ *
+ * @param value - Value to check.
+ * @returns `true` if the value is a configured value ({@link ConfiguredValue}), `false` otherwise.
+ */
+function isConfiguredValue(value: unknown): value is ConfiguredValue {
+  return typeof value !== 'undefined' &&
+    value !== null &&
+    typeof value === 'object' &&
+    'value' in value;
+}
+
+/** Utility type to check if a value is a valid store. */
+export type ValidStore = Record<PropertyKey, unknown>;
+
+/**
+ * Configuration options for a signal.
+ *
+ * @template T - The type of the signal value.
+ */
+export interface ConfiguredSignal<T = unknown> extends SignalOptions<T> {
+  /** Initial value of the signal.*/
+  value: T;
+}
+
+/**
+ * Configuration options for a memoized signal.
+ *
+ * @template T - The type of the signal value.
+ */
+export interface ConfiguredMemoSignal<T = unknown> extends MemoizedSignalOptions<T> {
+  /**
+   * Initial value of the signal.
+   *
+   * @returns The initial value of the signal.
+   */
+  value: () => T;
+}
+
+/**
+ * Utility type to define a configured value.
+ *
+ * @template T - The type of the signal value.
+ */
+export type ConfiguredValue<T = unknown> = ConfiguredSignal<T> | ConfiguredMemoSignal<T>;
+
+/**
+ * Utility type to add the meta data property to the state.
+ *
+ * @template T - The type of the store.
+ */
+export type StateWithMeta<T extends ValidStore> = T & { __id__: string };
+
+/**
+ * Maps all the values of the object as signals and actions.
+ *
+ * @template T - The type of the store.
+ */
+export type WritableState<T extends ValidStore> = StateWithMeta<
+  // Disabled since it's okay to use this type here to map the values of the state.
+  // deno-lint-ignore ban-types
+  { [K in keyof T]: T[K] extends Function ? T[K] : WritableSignal<T[K]> }
+>;
+
+/**
+ * Maps all the values of the object as readonly signals and actions.
+ *
+ * @template T - The type of the store.
+ */
+export type ReadonlyState<T extends ValidStore> = StateWithMeta<
+  // Disabled since it's okay to use this type here to map the values of the state.
+  // deno-lint-ignore ban-types
+  { [K in keyof T]: T[K] extends Function ? T[K] : ReadonlySignal<T[K]> }
+>;
+
+/**
+ * Function to create the store with the initial values.
+ *
+ * @template T - The type of the store.
+ */
+export type StoreValues<T extends ValidStore> = (values: {
+  /**
+   * Returns the current state of the store.
+   *
+   * `WritableState<T>` cannot be nullable, However, it's initially undefined when the store is
+   * created because the state isn't yet initialized. This ensures that the state is always
+   * accessible without needing constant null checks.
+   */
+  get: () => WritableState<T>;
+}) => {
+  // Disabled since it's okay to use this type here to map the values of the state.
+  // deno-lint-ignore ban-types
+  [K in keyof T]: T[K] extends Function ? T[K] : T[K] | ConfiguredValue<T[K]>;
+};
+
+/**
+ * A store is a function that returns an atomic and encapsulated state. It can be read through
+ * signals and written through actions.
+ *
+ * @template T - The type of the store.
+ */
+export interface Store<T extends ValidStore> {
+  /**
+   * Function to use the store.
+   *
+   * @template U - Key of the store to select.
+   * @param selector - Key of the store to select.
+   * @returns The value of the selected store key.
+   */
+  <U extends keyof T>(selector: U): ReadonlyState<T>[U];
+  /**
+   * Function to use the store.
+   *
+   * @returns The state of the store.
+   */
+  (): ReadonlyState<T>;
+}

--- a/reactivity/store_test.ts
+++ b/reactivity/store_test.ts
@@ -1,0 +1,198 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { assertSpyCalls, stub } from '@std/testing/mock';
+import { expect } from '@std/expect';
+
+import { delay } from '@std/async/delay';
+
+import { type Store, store } from './store.ts';
+
+type CounterStore = {
+  count: number;
+  increment: () => void;
+  decrement: () => void;
+  reset: () => void;
+  doubleCount: number;
+  name: string;
+};
+
+function createCounterStore(): Store<CounterStore> {
+  return store<CounterStore>(({ get }) => ({
+    count: 0,
+    increment: () => get().count.update((count) => count + 1),
+    decrement: () => get().count.update((count) => count - 1),
+    reset: () => get().count.set(0),
+    doubleCount: {
+      value: () => get().count() * 2,
+    },
+    name: {
+      value: 'Counter',
+    },
+  }));
+}
+
+Deno.test('store() should expose values, actions, and computed values', () => {
+  const counterStore = createCounterStore();
+  const counter = counterStore();
+
+  expect(counter.count()).toBe(0);
+
+  counter.increment();
+  expect(counter.count()).toBe(1);
+
+  counter.decrement();
+  expect(counter.count()).toBe(0);
+
+  counter.increment();
+  counter.increment();
+  expect(counter.count()).toBe(2);
+  expect(counter.doubleCount()).toBe(4);
+
+  counter.reset();
+  expect(counter.count()).toBe(0);
+
+  expect(counter.name()).toBe('Counter');
+});
+
+Deno.test('store() should apply signal configuration', () => {
+  using consoleStub = stub(console, 'log', (_) => {});
+  const changes: number[] = [];
+
+  const configuredCounterStore = store<CounterStore>(({ get }) => ({
+    name: 'Counter',
+    count: {
+      value: 0,
+      name: 'count',
+      log: true,
+      equal: (a, b) => a === b,
+      subscribe: (value) => changes.push(value),
+    },
+    increment: () => get().count.update((count) => count + 1),
+    decrement: () => get().count.update((count) => count - 1),
+    reset: () => get().count.set(0),
+    doubleCount: { value: () => get().count() * 2 },
+  }));
+
+  const counter = configuredCounterStore();
+
+  counter.increment();
+  counter.increment();
+  counter.increment();
+
+  expect(changes).toStrictEqual([1, 2, 3]);
+  assertSpyCalls(consoleStub, 9); // 9 calls since each log is called 3 times.
+});
+
+Deno.test('store() should return a specific value or action when given a selector', () => {
+  const counterStore = createCounterStore();
+  const count = counterStore('count');
+  const increment = counterStore('increment');
+
+  expect(count()).toBe(0);
+
+  increment();
+  expect(count()).toBe(1);
+
+  increment();
+  expect(count()).toBe(2);
+});
+
+Deno.test('store() should select values with an empty string key', () => {
+  const valueStore = store<{ '': number }>(() => ({ '': 42 }));
+
+  expect(valueStore('')()).toBe(42);
+});
+
+Deno.test('store() should support asynchronous actions', async () => {
+  type User = {
+    uid: string;
+    username: string;
+    password: string;
+  };
+
+  const mockedUsers: User[] = [];
+
+  const UserService = {
+    create: async (username: string, password: string) => {
+      await delay(5);
+      const user = { uid: `${mockedUsers.length + 1}`, username, password };
+      mockedUsers.push(user);
+      return user;
+    },
+    read: async (username: string) => {
+      await delay(5);
+      const user = mockedUsers.find((user) => user.username === username);
+      return user ?? null;
+    },
+    update: async (uid: string, username: string, password: string) => {
+      await delay(5);
+      const user = mockedUsers.find((user) => user.uid === uid);
+      if (user) {
+        user.username = username;
+        user.password = password;
+      }
+      return user ?? null;
+    },
+    delete: async (uid: string) => {
+      await delay(5);
+      const user = mockedUsers.find((user) => user.uid === uid);
+      if (user) {
+        mockedUsers.splice(mockedUsers.indexOf(user), 1);
+      }
+      return user ?? null;
+    },
+  };
+
+  type AuthStore = {
+    user: User | null;
+    uid: string | null;
+    signUp: (username: string, password: string) => Promise<User>;
+    signIn: (username: string, password: string) => Promise<User | null>;
+    signOut: () => Promise<boolean>;
+  };
+
+  const authenticationStore = store<AuthStore>(({ get }) => ({
+    user: null,
+    uid: {
+      value: () => get().user()?.uid ?? null, // uid is a derived value from user.
+    },
+    signIn: async (username, password) => {
+      const userSignedIn = await UserService.read(username);
+      if (userSignedIn?.password !== password) {
+        get().user.set(null);
+        return null;
+      }
+      get().user.set(userSignedIn);
+      return userSignedIn;
+    },
+    signOut: async () => {
+      await delay(5);
+      get().user.set(null);
+      return true;
+    },
+    signUp: async (username, password) => {
+      const newUser = await UserService.create(username, password);
+
+      get().user.set(newUser);
+
+      return newUser;
+    },
+  }));
+
+  const auth = authenticationStore();
+  expect(auth.uid()).toBe(null);
+
+  await auth.signUp('username', 'password');
+  expect(auth.uid()).toBe('1');
+
+  await auth.signOut();
+  expect(auth.uid()).toBe(null);
+
+  await auth.signIn('username', 'password');
+  expect(auth.uid()).toBe('1');
+  expect(auth.user()).toStrictEqual({ uid: '1', username: 'username', password: 'password' });
+
+  await auth.signOut();
+  expect(auth.uid()).toBe(null);
+  expect(auth.user()).toBe(null);
+});

--- a/reactivity/to_signal.ts
+++ b/reactivity/to_signal.ts
@@ -1,0 +1,82 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the implementation for the {@link toSignal} function.
+ *
+ * A promise signal is a signal that resolves a promise and updates its value based on the promise's
+ * status.
+ *
+ * @example Usage
+ * ```ts
+ * const promiseSignal = toSignal(() => fetch('https://api.example.com/data'));
+ *
+ * console.log(promiseSignal()); // Logs: "{ status: 'pending' }".
+ *
+ * // The value is updated when the promise resolves.
+ * await delay(1000);
+ * console.log(promiseSignal()); // Logs: "{ status: 'fulfilled', value: 'Hello, World!' }".
+ *
+ * // Or if the promise rejects.
+ * console.log(promiseSignal()); // Logs: "{ status: 'rejected', error: 'Error!' }".
+ * ```
+ *
+ * @module
+ */
+
+import type { ReadonlySignal } from './_api.ts';
+import { signal } from './signal.ts';
+
+/**
+ * Creates a signal from a promise.
+ *
+ * @example Usage
+ * ```ts
+ * // Create a signal from a promise using async/await.
+ * const promiseSignal = toSignal(async () => {
+ *   const response = await fetch('https://api.example.com/data');
+ *   return await response.json();
+ * });
+ *
+ * // Or using a promise directly.
+ * const promiseSignal = toSignal(
+ *   fetch('https://api.example.com/data').then((response) => response.json())
+ * );
+ *
+ * // The signal is initially pending.
+ * console.log(promiseSignal()); // Logs: "{ status: 'pending' }".
+ *
+ * // The value is updated when the promise resolves.
+ * await delay(1000);
+ * console.log(promiseSignal()); // Logs: "{ status: 'fulfilled', value: 'Hello, World!' }".
+
+ * // Or if the promise rejects.
+ * console.log(promiseSignal()); // Logs: "{ status: 'rejected', error: 'Error!' }".
+ * ```
+ *
+ * @template T - The type of the promise value.
+ * @param value - Promise function or promise to create the signal from.
+ * @returns A read-only signal ({@link ReadonlySignal}) that resolves the promise and updates its
+ * value based on the promise's status.
+ */
+export function toSignal<T>(
+  value: (() => Promise<T>) | Promise<T>,
+): ReadonlySignal<PromiseValue<T>> {
+  const signalValue = signal<PromiseValue<T>>({ status: 'pending' });
+
+  const promise = value instanceof Promise ? value : value();
+
+  promise
+    .then((response) => signalValue.set({ status: 'fulfilled', value: response }))
+    .catch((error) => signalValue.set({ status: 'rejected', error }));
+
+  return signalValue.readonly();
+}
+
+/**
+ * The value of a promise.
+ * @template T - The type for the promise value.
+ */
+export type PromiseValue<T> =
+  | { status: 'pending' }
+  | { status: 'fulfilled'; value: T }
+  | { status: 'rejected'; error: unknown };

--- a/reactivity/to_signal_test.ts
+++ b/reactivity/to_signal_test.ts
@@ -1,0 +1,30 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { expect } from '@std/expect';
+
+import { delay } from '@std/async';
+
+import { toSignal } from './to_signal.ts';
+
+Deno.test('toSignal() should create signals from promises and promise functions', async () => {
+  const promise1 = toSignal(() => delay(10).then(() => 'Hello, World!'));
+  const promise2 = toSignal(delay(10).then(() => 'Hello, World!'));
+
+  expect(promise1()).toStrictEqual({ status: 'pending' });
+  expect(promise2()).toStrictEqual({ status: 'pending' });
+
+  await delay(20);
+
+  expect(promise1()).toStrictEqual({ status: 'fulfilled', value: 'Hello, World!' });
+  expect(promise2()).toStrictEqual({ status: 'fulfilled', value: 'Hello, World!' });
+});
+
+Deno.test('toSignal() should expose rejected promise errors', async () => {
+  const promise = toSignal(() => delay(10).then(() => Promise.reject('Error!')));
+
+  expect(promise()).toStrictEqual({ status: 'pending' });
+
+  await delay(20);
+
+  expect(promise()).toStrictEqual({ status: 'rejected', error: 'Error!' });
+});

--- a/reactivity/untracked.ts
+++ b/reactivity/untracked.ts
@@ -1,0 +1,32 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the implementation for the {@link untrackedSignal} function.
+ *
+ * A signal is a reactive value that can be read and watched for changes. However, sometimes you
+ * need to read a signal without creating a dependency. This function allows you to read the value
+ * of a signal without creating a dependency.
+ *
+ * @module
+ */
+
+import { ReactiveNode } from './_reactive_node.ts';
+
+/**
+ * Reads the value of a signal without creating a dependency.
+ *
+ * @template T - The type of the signal value.
+ * @param readFn - The function to read the signal value.
+ * @returns The value of the signal.
+ */
+export function untrackedSignal<T>(readFn: () => T): T {
+  const previousConsumer = ReactiveNode.setActiveConsumer(null);
+
+  // We are not trying to catch any particular errors here, just making sure that the consumers
+  // stack is restored in case of errors.
+  try {
+    return readFn();
+  } finally {
+    ReactiveNode.setActiveConsumer(previousConsumer);
+  }
+}

--- a/reactivity/untracked_test.ts
+++ b/reactivity/untracked_test.ts
@@ -1,0 +1,25 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { expect } from '@std/expect';
+
+import { untrackedSignal } from './untracked.ts';
+import { signal } from './signal.ts';
+import { effect } from './effect.ts';
+
+Deno.test('untrackedSignal() should read without tracking dependencies', () => {
+  const changes: number[] = [];
+
+  const counter = signal(0);
+
+  effect(() => {
+    changes.push(untrackedSignal(() => counter()));
+  });
+
+  counter.set(1);
+
+  expect(changes).toStrictEqual([]);
+
+  counter.set(2);
+
+  expect(changes).toStrictEqual([]);
+});


### PR DESCRIPTION
## Summary

Add the reactivity module to the Fragment ecosystem.

This module provides framework-agnostic reactive state management through signals, memoized values, effects, asynchronous signals, and structured stores. It has been migrated into the Fragment monorepo as an independent Deno workspace package.

The module includes:

- Writable and read-only signals
- Memoized signals for derived values
- Reactive effects with automatic dependency tracking
- Untracked signal reads
- Promise and asynchronous value conversion
- Structured stores with values, computed state, and actions
- Event-based signal updates
- Configurable signal logging
- Disposable effects and event signals
- Public TypeScript APIs and module documentation

The repository configuration has also been updated to:

- Register `reactivity` as a Deno workspace member
- Generate and commit the shared Deno lockfile
- Include the module in repository-wide formatting, linting, type-checking, documentation validation, testing, and coverage
- Preserve the module's existing README and usage examples

The complete repository quality gate passes with 60 tests and 100% branch, function, and line coverage.

## Checklist before requesting a review

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).